### PR TITLE
Add GitHub workflow for clang-format

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+---
+on: [push]
+name: Lint
+jobs:
+  lint-clang-format:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install clang-format
+        run: sudo apt-get install -y clang-format
+      
+      - name: Verify formatting
+        run: |
+          find source -type f \
+               -name '*.h' \
+            -o -name '*.c' \
+            -o -name '*.hpp' \
+            -o -name '*.cpp' \
+            -exec clang-format --dry-run --Werror {} +

--- a/source/egg/core/eggArchive.cpp
+++ b/source/egg/core/eggArchive.cpp
@@ -32,7 +32,7 @@ Archive* Archive::mount(void* arcStart, Heap* pHeap, int align) {
       archive->mStatus = NOT_LOADED;
       EGG_ASSERT(false, "eggArchive.cpp", 166, "false");
     }
-  
+
     // If we failed, clean up
     if (!could_create) // INLINE
     {

--- a/source/egg/core/eggDvdFile.cpp
+++ b/source/egg/core/eggDvdFile.cpp
@@ -28,7 +28,6 @@ void DvdFile::initiate() {
   this->_38 = 0;
 }
 
-
 bool DvdFile::open(s32 entryNum) {
   if (!this->mIsOpen && entryNum != -1) {
     if (mFileInfo.open(entryNum)) {
@@ -61,8 +60,9 @@ int DvdFile::readData(void* addr, int len, int offset) {
   }
   this->_C4 = OSGetCurrentThread();
   int r31 = (void*)-1;
-	if (DVDReadAsyncPrio(&this->mFileInfo, addr, len, offset, (DVDCallback)&doneProcess, 2))
-		r31 = this->sync();
+  if (DVDReadAsyncPrio(&this->mFileInfo, addr, len, offset,
+                       (DVDCallback)&doneProcess, 2))
+    r31 = this->sync();
   this->_C4 = 0;
   OSUnlockMutex(&this->Mutex_08);
   return r31;

--- a/source/egg/core/eggExpHeap.cpp
+++ b/source/egg/core/eggExpHeap.cpp
@@ -10,7 +10,7 @@
 inline void* operator new(unsigned long, void* p) { return p; }
 
 namespace EGG {
-    
+
 enum {
   EXP_HEAP_BASE_SIZE = 56, // (sizeof(ExpHeap) - sizeof(...)),
   EXP_HEAP_ALIGN = 4
@@ -26,7 +26,7 @@ ExpHeap::~ExpHeap() {
 
 #ifdef NONMATCHING
 ExpHeap* ExpHeap::create(void* block, u32 size, u16 attr) {
-  ExpHeap* createdHeap = nullptr;                                       // r30
+  ExpHeap* createdHeap = nullptr; // r30
 
   u32 heapEnd = nw4r::ut::RoundDown((u32)block + size, EXP_HEAP_ALIGN); // r3
   u32 heapStart = nw4r::ut::RoundUp((u32)block, EXP_HEAP_ALIGN);        // r27
@@ -58,7 +58,7 @@ ExpHeap* ExpHeap::create(void* block, u32 size, u16 attr) {
 extern "C" void __ct__Q23EGG4HeapFP12MEMiHeapHead();
 extern "C" void findContainHeap__Q23EGG4HeapFPCv();
 
-// clang-format off[
+// clang-format off
 asm ExpHeap* ExpHeap::create(void* block, u32 size, u16 attr) {
     nofralloc
 

--- a/source/egg/core/eggUnitHeap.cpp
+++ b/source/egg/core/eggUnitHeap.cpp
@@ -64,7 +64,8 @@ UnitHeap* UnitHeap::create(u32 size, u32 unit_size, EGG::Heap* heap, s32 align,
 
   block = heap->alloc(size, UNIT_HEAP_ALIGN);
   if (block) {
-    if ((ret = create(block, size, unit_size, align, flag)) != nullptr) // INLINE
+    if ((ret = create(block, size, unit_size, align, flag)) !=
+        nullptr) // INLINE
       ret->mParentHeap = heap;
     else
       heap->free(block);

--- a/source/egg/util/eggCntFile.cpp
+++ b/source/egg/util/eggCntFile.cpp
@@ -1,7 +1,7 @@
 #include <EGG/util/eggCntFile.hpp>
 
 namespace EGG {
-  
+
 CntFile::CntFile() {}
 CntFile::~CntFile() {}
 

--- a/source/game/host_system/SystemManager.cpp
+++ b/source/game/host_system/SystemManager.cpp
@@ -11,37 +11,35 @@ namespace System {
 static const char* sRegionCode = "RMCP";
 static const char* MAIN_SMAP = "/rel/RevoKartR.SMAP";
 
-
 SystemManager* SystemManager::sInstance;
 
 SystemManager* SystemManager::initStaticInstance(EGG::Heap* heap) {
   return (sInstance = new SystemManager(heap));
 }
-SystemManager::~SystemManager() {
-  delete[] this->buf_88;
-}
+SystemManager::~SystemManager() { delete[] this->buf_88; }
 
 void SystemManager::LoadSymbols(OSModuleInfo* pModuleInfo) {
-	pModuleInfo = pModuleInfo != nullptr ? pModuleInfo : this->_B0; // r5
+  pModuleInfo = pModuleInfo != nullptr ? pModuleInfo : this->_B0; // r5
 
-	if (pModuleInfo == nullptr)
-		return;
+  if (pModuleInfo == nullptr)
+    return;
 
-	if (MAIN_SMAP != nullptr) // "/rel/RevoKartR.SMAP"
-	{
-		u32 map_size;
-		mpMap = SystemManager::sInstance->ripFromDisc(MAIN_SMAP, pModuleInfo, 0, &map_size, 0);
-		if (mpMap != nullptr) {
-			EGG::Exception::setMapFile(mpMap, map_size, pModuleInfo);
-			OSReport("[SYS] Load MapFile \"%s\" success.\n", MAIN_SMAP);
-		} else {
-			OSReport("[SYS] Load MapFile \"%s\" fail.\n", MAIN_SMAP);
-		}
-	}
-	
+  if (MAIN_SMAP != nullptr) // "/rel/RevoKartR.SMAP"
+  {
+    u32 map_size;
+    mpMap = SystemManager::sInstance->ripFromDisc(MAIN_SMAP, pModuleInfo, 0,
+                                                  &map_size, 0);
+    if (mpMap != nullptr) {
+      EGG::Exception::setMapFile(mpMap, map_size, pModuleInfo);
+      OSReport("[SYS] Load MapFile \"%s\" success.\n", MAIN_SMAP);
+    } else {
+      OSReport("[SYS] Load MapFile \"%s\" fail.\n", MAIN_SMAP);
+    }
+  }
+
   buf_88->_0 = 0;
-	buf_8C->_0 = 0;
-	buf_90->_0 = 0;
+  buf_8C->_0 = 0;
+  buf_90->_0 = 0;
 }
 
 } // namespace System


### PR DESCRIPTION
- [x] Adds a CI config that runs `clang-format` on every new commit, failing CI any code is formatted incorrectly.
- [x] Fixes formatting on presently incorrectly formatted sources.