### PR TITLE
build.py: auto-discover devkitPPC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ mwasmeppc.exe
 mwcceppc.exe
 mwldeppc.exe
 makedol.exe
+powerpc-eabi-as.exe
 *.out
 *.app
 


### PR DESCRIPTION
This patch changes `build.py` to fall back to `.\tools/devkitppc` when env var `$DEVKITPPC` is not set.

Motivation: First time using Windows and I have no idea how to set env vars. It's more convenient if the build script runs without any special env.