### PR TITLE
percent_decompiled.py: Ignore inline asm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,6 @@ jobs:
       - name: Install dependencies
         run: pip3 install -r requirements.txt
 
-      - name: Percent decompiled
-        run: python3 -m mkwutil.percent_decompiled
-
       - name: Extract tooling
         env:
           TOOLS_URL: 'http://163.172.81.216:12369/tools.7z'

--- a/mkwutil/gen_asm/source.c.j2
+++ b/mkwutil/gen_asm/source.c.j2
@@ -17,6 +17,7 @@ UNKNOWN_FUNCTION({{ function.name }});
 // Symbol: {{ function.name }}
 // Function signature is unknown.
 // PAL: {{ function.addr | addr }}..{{ (function.addr+function.size) | addr }}
+MARK_BINARY_BLOB({{ function.name }}, {{ function.addr | addr }}, {{ (function.addr+function.size) | addr }});
 asm UNKNOWN_FUNCTION({{ function.name }}) {
   nofralloc;
 {%- for line in function.inline_asm %}

--- a/mkwutil/pack_main_dol.py
+++ b/mkwutil/pack_main_dol.py
@@ -8,14 +8,19 @@ from elftools.elf.constants import P_FLAGS
 from elftools.elf.elffile import ELFFile
 
 
+def segment_is_dummy(seg):
+    """Returns whether segment contains dummy info."""
+    return seg["p_vaddr"] == 0xA000_0000  # Binary blobs section
+
+
 def segment_is_text(seg):
     """Returns whether segment is executable text."""
-    return seg["p_flags"] & P_FLAGS.PF_X == P_FLAGS.PF_X
+    return not segment_is_dummy(seg) and seg["p_flags"] & P_FLAGS.PF_X == P_FLAGS.PF_X
 
 
 def segment_is_data(seg):
     """Returns whether segment is data."""
-    return not segment_is_text(seg) and not segment_is_bss(seg)
+    return not segment_is_dummy(seg) and not segment_is_text(seg) and not segment_is_bss(seg)
 
 
 def segment_is_bss(seg):

--- a/mkwutil/percent_decompiled.py
+++ b/mkwutil/percent_decompiled.py
@@ -1,11 +1,14 @@
 from copy import copy
 from pathlib import Path
+import re
+from typing import Generator
 
+from elftools.elf.elffile import ELFFile, Section as ELFSection
 import pytablewriter
 from pytablewriter.style import Style
 from termcolor import colored
 
-from mkwutil.slices import SliceTable
+from mkwutil.slices import Slice, SliceTable
 from mkwutil.sections import Section, REL_SECTIONS, DOL_SECTIONS, DOL_LIBS
 
 
@@ -59,12 +62,47 @@ def get_progress(slices, filter):
     return progress
 
 
+MATCH_BINARY_BLOB = re.compile(
+    rb"BINARY_BLOB: (.+)\t(0x[0-9a-f]{8})\t(0x[0-9a-f]{8})\n"
+)
+
+
+def __load_binary_blob_slices(elf_file) -> Generator[Slice, None, None]:
+    elf = ELFFile(elf_file)
+    blobs: ELFSection = elf.get_section_by_name("binary_blobs")
+    if not blobs:
+        return
+    for match in MATCH_BINARY_BLOB.finditer(blobs.data()):
+        name = match.group(1).decode("ascii")
+        start, stop = int(match.group(2), 16), int(match.group(3), 16)
+        yield Slice(start, stop, name)
+
+
+def load_binary_blob_slices(elf_path: Path) -> SliceTable:
+    """Loads all inline assembly slices from the ELF."""
+    with open(elf_path, "rb") as file:
+        return list(__load_binary_blob_slices(file))
+
+
+def mask_binary_blobs(main_slices: SliceTable, blob_slices: list[Slice]) -> None:
+    """Inserts a gap into the given slice table for each blob slice.
+    This is used to remove all inline ASM slices from the slice table, leaving only actual C/C++ code."""
+    for _slice in blob_slices:
+        # print("Ignoring", _slice)
+        main_slices.remove(_slice=_slice)
+    # print(main_slices)
+
+
 def percent_decompiled(dir="."):
     dir = Path(dir)
 
     matrix = []
     # DOL progress.
     dol_slices = SliceTable.load_dol_slices()
+    dol_blob_slices = load_binary_blob_slices(
+        dir / "artifacts" / "target" / "pal" / "main.elf"
+    )
+    mask_binary_blobs(dol_slices, dol_blob_slices)
     dol_progress = simple_count(dol_slices)
     dol_total = binary_total(DOL_SECTIONS)
     matrix.append(analyze("DOL", dol_progress, dol_total))

--- a/mkwutil/percent_decompiled.py
+++ b/mkwutil/percent_decompiled.py
@@ -78,7 +78,7 @@ def __load_binary_blob_slices(elf_file) -> Generator[Slice, None, None]:
         yield Slice(start, stop, name)
 
 
-def load_binary_blob_slices(elf_path: Path) -> SliceTable:
+def load_binary_blob_slices(elf_path: Path) -> list[Slice]:
     """Loads all inline assembly slices from the ELF."""
     with open(elf_path, "rb") as file:
         return list(__load_binary_blob_slices(file))

--- a/mkwutil/slices.py
+++ b/mkwutil/slices.py
@@ -251,6 +251,7 @@ class SliceTable:
             begin_slice = Slice(start, old_stop)
             self.slices.insert(i + 1, begin_slice)
             i += 2
+            # If gap stops within named slice, create copy of original slice.
             if old_stop > stop:
                 end_slice = copy(old_slice)
                 end_slice.start = stop
@@ -261,17 +262,6 @@ class SliceTable:
             begin_slice = self.slices[i - 1]
         else:
             i += 1
-        # If gap ends in current slice, create a copy.
-        if stop < begin_slice.stop and begin_slice.has_name():
-            old_stop = begin_slice.stop
-            begin_slice.stop = start
-            self.slices.insert(i, Slice(start, stop))
-            i += 1
-            end_slice = copy(begin_slice)
-            end_slice.start = stop
-            end_slice.stop = old_stop
-            self.slices.insert(i, end_slice)
-            return
         # Extend slice.
         begin_slice.name = None
         begin_slice.stop = stop

--- a/mkwutil/slices.py
+++ b/mkwutil/slices.py
@@ -18,6 +18,8 @@ class Slice:
     tags: set[str] = field(default_factory=set)
 
     def __post_init__(self):
+        assert isinstance(self.start, int)
+        assert isinstance(self.stop, int)
         assert self.start <= self.stop
 
     def __contains__(self, key) -> bool:
@@ -65,7 +67,7 @@ class Slice:
 class ObjectSlices:
     """ObjectSlices is an immutable view of slices grouped by slice name."""
 
-    objects: dict=field(default_factory=dict)
+    objects: dict = field(default_factory=dict)
 
     def get(self, name: str) -> list[Slice]:
         assert isinstance(name, str)
@@ -79,7 +81,7 @@ class SliceTable:
     """A list of contiguous slices for a given range."""
 
     def __init__(
-        self, start=0x8000_0000, stop=math.inf, sections: Optional[list] = None
+        self, start=0x8000_0000, stop=0x1_0000_0000, sections: Optional[list] = None
     ):
         if sections is not None:
             start = sections[0].start
@@ -199,7 +201,7 @@ class SliceTable:
         """Adds a slice to the table, changing gaps as appropriate.
         Panics if a named slice overlaps with the slice to be inserted"""
         assert isinstance(_slice, Slice)
-        assert(len(_slice) > 0), str(_slice)
+        assert len(_slice) > 0, str(_slice)
         assert _slice in self, "Slice %08x..%08x does not fit in table %08x..%08x" % (
             _slice.start,
             _slice.stop,
@@ -226,6 +228,62 @@ class SliceTable:
         # Insert right gap.
         if _slice.stop < target.stop:
             self.slices.insert(i + 1, Slice(_slice.stop, target.stop))
+
+    def remove(self, start: int = None, stop: int = None, _slice: Slice = None) -> None:
+        """Removes the specified range or slice and inserts a gap at its place."""
+        if isinstance(_slice, Slice):
+            return self.__remove(_slice.start, _slice.stop)
+        else:
+            return self.__remove(start, stop)
+
+    def __remove(self, start: int, stop: int) -> None:
+        assert isinstance(start, int)
+        assert isinstance(stop, int)
+        start = max(start, self.start)
+        stop = min(stop, self.stop)
+        # Search for the beginning of the gap.
+        begin_slice, i = self.find(start)
+        # If gap starts within named slice, create new gap slice.
+        if begin_slice.start < start and begin_slice.has_name():
+            old_stop = begin_slice.stop
+            begin_slice.stop = start
+            old_slice = begin_slice
+            begin_slice = Slice(start, old_stop)
+            self.slices.insert(i + 1, begin_slice)
+            i += 2
+            if old_stop > stop:
+                end_slice = copy(old_slice)
+                end_slice.start = stop
+                end_slice.stop = old_stop
+                self.slices.insert(i, end_slice)
+        # If bordering with a gap on the left, select gap.
+        elif begin_slice.start == start and i > 0 and not self.slices[i - 1].has_name():
+            begin_slice = self.slices[i - 1]
+        else:
+            i += 1
+        # If gap ends in current slice, create a copy.
+        if stop < begin_slice.stop and begin_slice.has_name():
+            old_stop = begin_slice.stop
+            begin_slice.stop = start
+            self.slices.insert(i, Slice(start, stop))
+            i += 1
+            end_slice = copy(begin_slice)
+            end_slice.start = stop
+            end_slice.stop = old_stop
+            self.slices.insert(i, end_slice)
+            return
+        # Extend slice.
+        begin_slice.name = None
+        begin_slice.stop = stop
+        # Remove overlapping slices.
+        while i < len(self.slices) and self.slices[i].stop <= stop:
+            self.slices.pop(i)
+        if i < len(self.slices):
+            self.slices[i].start = stop
+        # If bordering with a right gap, merge gaps.
+        if i < len(self.slices) and not self.slices[i].has_name():
+            begin_slice.stop = self.slices[i].stop
+            self.slices.pop(i)
 
     def __repr__(self) -> str:
         return (

--- a/mkwutil/slices_test.py
+++ b/mkwutil/slices_test.py
@@ -114,6 +114,23 @@ def test_slice_table_remove_6():
 ]"""
 
 def test_slice_table_remove_7():
+    # Remove slice prefix.
+    table = SliceTable(0, 6)
+    for x in range(2, 6, 2):
+        table.add(Slice(x, x+2, "slice"))
+    assert str(table) == """[
+  { 00000000..00000002 }
+  { 00000002..00000004 slice }
+  { 00000004..00000006 slice }
+]"""
+    table.remove(0, 3)
+    assert str(table) == """[
+  { 00000000..00000003 }
+  { 00000003..00000004 slice }
+  { 00000004..00000006 slice }
+]"""
+
+def test_slice_table_remove_8():
     # Remove slice suffix.
     table = SliceTable(0, 6)
     for x in range(0, 4, 2):

--- a/mkwutil/slices_test.py
+++ b/mkwutil/slices_test.py
@@ -28,6 +28,107 @@ def test_slice_table():
         Slice(14, 16),
     ]
 
+def test_slice_table_remove_1():
+    # Create a gap spanning some slices.
+    table = SliceTable(0, 10)
+    for x in range(2, 10, 2):
+        table.add(Slice(x, x+2, "slice"))
+    assert str(table) == """[
+  { 00000000..00000002 }
+  { 00000002..00000004 slice }
+  { 00000004..00000006 slice }
+  { 00000006..00000008 slice }
+  { 00000008..0000000a slice }
+]"""
+    table.remove(3, 7)
+    assert str(table) == """[
+  { 00000000..00000002 }
+  { 00000002..00000003 slice }
+  { 00000003..00000007 }
+  { 00000007..00000008 slice }
+  { 00000008..0000000a slice }
+]"""
+
+
+def test_slice_table_remove_2():
+    # Create a gap spanning the entire table.
+    table = SliceTable(0, 10)
+    for x in range(0, 10, 2):
+        table.add(Slice(x, x+2, "slice"))
+    table.remove(0, 10)
+    assert str(table) == """[
+  { 00000000..0000000a }
+]"""
+
+def test_slice_table_remove_3():
+    # Create a gap where a gap already is.
+    table = SliceTable(0, 6)
+    for x in range(2, 6, 2):
+        table.add(Slice(x, x+2, "slice"))
+    table.remove(0, 2)
+    assert str(table) == """[
+  { 00000000..00000002 }
+  { 00000002..00000004 slice }
+  { 00000004..00000006 slice }
+]"""
+
+
+def test_slice_table_remove_4():
+    # Shoot a hole in a slice.
+    table = SliceTable(0, 10)
+    table.add(Slice(0, 10, "slice"))
+    table.remove(4, 5)
+    assert str(table) == """[
+  { 00000000..00000004 slice }
+  { 00000004..00000005 }
+  { 00000005..0000000a slice }
+]"""
+
+def test_slice_table_remove_5():
+    # Remove exact slice.
+    table = SliceTable(0, 6)
+    for x in range(0, 6, 2):
+        table.add(Slice(x, x+2, "slice"))
+    table.remove(2, 4)
+    assert str(table) == """[
+  { 00000000..00000002 slice }
+  { 00000002..00000004 }
+  { 00000004..00000006 slice }
+]"""
+
+def test_slice_table_remove_6():
+    # Remove slice prefix.
+    table = SliceTable(0, 6)
+    for x in range(2, 6, 2):
+        table.add(Slice(x, x+2, "slice"))
+    assert str(table) == """[
+  { 00000000..00000002 }
+  { 00000002..00000004 slice }
+  { 00000004..00000006 slice }
+]"""
+    table.remove(2, 3)
+    assert str(table) == """[
+  { 00000000..00000003 }
+  { 00000003..00000004 slice }
+  { 00000004..00000006 slice }
+]"""
+
+def test_slice_table_remove_7():
+    # Remove slice suffix.
+    table = SliceTable(0, 6)
+    for x in range(0, 4, 2):
+        table.add(Slice(x, x+2, "slice"))
+    assert str(table) == """[
+  { 00000000..00000002 slice }
+  { 00000002..00000004 slice }
+  { 00000004..00000006 }
+]"""
+    table.remove(3, 4)
+    assert str(table) == """[
+  { 00000000..00000002 slice }
+  { 00000002..00000003 slice }
+  { 00000003..00000006 }
+]"""
 
 def test_dol_slices():
     table = SliceTable.load_dol_slices()
@@ -42,13 +143,3 @@ def test_rel_slices():
     assert isinstance(table, SliceTable)
     objs = table.object_slices()
     assert isinstance(objs, ObjectSlices)
-
-
-def test_object_slices_sort_names():
-    objects = ObjectSlices()
-    objects.insert(Slice(name="s0", start=0x01, stop=0x02, section="text"))
-    objects.insert(Slice(name="s2", start=0x06, stop=0x07, section="data"))
-    objects.insert(Slice(name="s3", start=0x03, stop=0x04, section="text"))
-    objects.insert(Slice(name="s1", start=0x02, stop=0x03, section="text"))
-    objects.insert(Slice(name="s1", start=0x05, stop=0x06, section="data"))
-    assert objects.sorted_names(order=["text", "data"]) == ["s0", "s1", "s2", "s3"]

--- a/pack/dol.lcf.j2
+++ b/pack/dol.lcf.j2
@@ -1,6 +1,8 @@
 ENTRY(__start)
 MEMORY {
 text : origin = 0x80004000
+// Dummy address
+binary_blobs : origin = 0xA0000000
 }
 SECTIONS {
 GROUP:{
@@ -19,6 +21,9 @@ extabindex_ ALIGN(0x20):{}
 .sbss2 ALIGN(0x20):{}
 .stack ALIGN(0x100):{}
 } > text
+GROUP:{
+binary_blobs ALIGN(0x20):{}
+} > binary_blobs
 
 _stack_addr = (_f_sbss2 + SIZEOF(.sbss2) + 65536 + 0x7) & ~0x7;
 _stack_end = _f_sbss2 + SIZEOF(.sbss2);

--- a/source/decomp.h
+++ b/source/decomp.h
@@ -1,3 +1,10 @@
 #pragma once
 
 #define UNKNOWN_FUNCTION(name) void name(void)
+
+#pragma section "binary_blobs"
+#define MARK_BINARY_BLOB(name, start, stop) \
+  __declspec(section "binary_blobs") \
+  static const char MARK_BINARY_BLOB_##name[] \
+  = "BINARY_BLOB: " #name "\t" #start "\t" #stop "\n" \
+  __attribute__((force_export))

--- a/source/decomp.h
+++ b/source/decomp.h
@@ -3,8 +3,8 @@
 #define UNKNOWN_FUNCTION(name) void name(void)
 
 #pragma section "binary_blobs"
-#define MARK_BINARY_BLOB(name, start, stop) \
-  __declspec(section "binary_blobs") \
-  static const char MARK_BINARY_BLOB_##name[] \
-  = "BINARY_BLOB: " #name "\t" #start "\t" #stop "\n" \
-  __attribute__((force_export))
+#define SECTION_BINARY_BLOBS __declspec(section "binary_blobs")
+#define MARK_BINARY_BLOB(name, start, stop)                                    \
+  SECTION_BINARY_BLOBS static const char MARK_BINARY_BLOB_##name[] =           \
+      "BINARY_BLOB: " #name "\t" #start "\t" #stop "\n"                        \
+      __attribute__((force_export))


### PR DESCRIPTION
Adds a macro `MARK_BINARY_BLOB(name, start, stop)` to allow the decompiled progress tracker to ignore inline asm sections.

Adds a new `binary_blobs` segment and section to the ELF containing a text list of locations of binary blobs to be loaded at dummy address `0xA000_0000`.
For each invocation of the `MARK_BINARY_BLOB` macro there an entry in the `binary_blobs` section of the form `"BINARY_BLOB: <name>\t0x<start>\t0x<stop>\n"`.

The `binary_blobs` section gets omitted when compiling to DOL.

`percent_decompiled.py` is instructed to scrape the ELF's `binary_blobs` section and filters out all slices using regex.

Adds a new function `SliceTable.remove()` that's used to re-insert gaps into the SliceTable.
To be honest, I don't know how the algorithm works myself (I hammered it until it works) but I've added extensive test cases.

Closes #41