### PR TITLE
Fix disabling rel slices

### DIFF
--- a/mkwutil/gen_asm.py
+++ b/mkwutil/gen_asm.py
@@ -482,8 +482,7 @@ def gen_asm(regen_asm=False):
     rel_bin_dir = binary_dir / "rel"
     dump_staticr(rel, rel_bin_dir)
     # Map out slices in REL.
-    rel_slices = load_rel_slices(sections=REL_SECTIONS)
-    rel_slices.filter(SliceTable.ONLY_ENABLED)
+    rel_slices = load_rel_slices(sections=REL_SECTIONS).filter(SliceTable.ONLY_ENABLED)
     # Disassemble REL sections.
     rel_asm_dir = asm_dir / "rel"
     rel_asm_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
Small fix to make disabling rel slices work.
Filter returns a new SliceTable with filtered contents, rather than filtering out unwanted slices in the existing SliceTable, so just doing rel_slices.filter here doesn't work.