### PR TITLE
Add rel directories to progress table and graph

### DIFF
--- a/mkwutil/progress/graphic.py
+++ b/mkwutil/progress/graphic.py
@@ -10,7 +10,7 @@ import jinja2
 from pytablewriter import HtmlTableWriter
 from pytablewriter.style import Style
 
-from mkwutil.sections import DOL_LIBS, DOL_SECTIONS, REL_SECTIONS
+from mkwutil.sections import DOL_LIBS, DOL_SECTIONS, REL_SECTIONS, REL_DIRS
 from mkwutil.lib.slices import Slice, SliceTable
 import mkwutil.project as project 
 from mkwutil.progress.percent_decompiled import build_stats
@@ -85,7 +85,7 @@ def percent_decomp_stats(slices: SliceTable) -> None:
 
     print("Code&Data Percent: %s" % (100 * n_code / total))
 
-def standard_boxes():
+def dol_boxes():
     slices = project.load_dol_slices(sections=DOL_SECTIONS)
     return map(Box.from_slice, slices)
 
@@ -108,9 +108,15 @@ def rel_section_boxes():
         slices.add(section_to_slice(s))
     return map(Box.from_slice, slices)
 
-def lib_boxes():
+def dol_lib_boxes():
     slices = SliceTable(sections=DOL_SECTIONS)
     for _slice in DOL_LIBS:
+        slices.add(_slice)
+    return map(Box.from_slice, slices)
+
+def rel_dir_boxes():
+    slices = SliceTable(sections=REL_DIRS)
+    for _slice in REL_DIRS:
         slices.add(_slice)
     return map(Box.from_slice, slices)
 
@@ -148,11 +154,12 @@ if __name__ == "__main__":
         jinja_env.get_template("index.html.j2").stream(
             {
                 "percents_table": percent_decompiled_table(),
-                "dol_decomp": standard_boxes(),
-                "dol_libraries": lib_boxes(),
+                "dol_decomp": dol_boxes(),
+                "dol_libraries": dol_lib_boxes(),
                 "dol_sections": dol_section_boxes(),
                 "rel_decomp": rel_boxes(),
                 "rel_sections": rel_section_boxes(),
+                "rel_directories": rel_dir_boxes(),
             }
         ).dump(file)
     if not args.silent:

--- a/mkwutil/progress/graphic/index.html.j2
+++ b/mkwutil/progress/graphic/index.html.j2
@@ -74,6 +74,9 @@ td, th {
 <h2>DOL Sections</h2>
 {{ slices(dol_sections, "rectangle-tooltip") }}
 
+<h2>REL Directories</h2>
+{{ slices(rel_directories, "rectangle-tooltip") }}
+
 <h2>REL Decompiled</h2>
 {{ slices(rel_decomp, "rectangle-tooltip rectangle-below") }}
 

--- a/mkwutil/progress/percent_decompiled.py
+++ b/mkwutil/progress/percent_decompiled.py
@@ -7,7 +7,7 @@ from pytablewriter.style import Style
 from termcolor import colored
 
 from mkwutil.lib.slices import SliceTable
-from mkwutil.sections import Section, REL_SECTIONS, DOL_SECTIONS, DOL_LIBS
+from mkwutil.sections import Section, DOL_SECTIONS, DOL_LIBS, REL_SECTIONS, REL_DIRS
 
 from mkwutil.project import *
 
@@ -163,6 +163,24 @@ def build_stats(dir: Path) -> Stats:
             rel_total_data,
         )
     )
+    # REL directories.
+    for dir in REL_DIRS:
+        assert dir.section == "text", "For now only text section per directory supported"
+        dir_split_slices = rel_split_slices.slice(dir.start, dir.stop)
+        dir_decomp_slices = rel_decomp_slices.slice(dir.start, dir.stop)
+        dir_split_code, _ = simple_count(dir_split_slices)
+        dir_decomp_code, _ = simple_count(dir_decomp_slices)
+        dir_total_code = len(dir)
+        matrix.append(
+            analyze(
+                "> " + dir.name,
+                dir_split_code,
+                dir_decomp_code,
+                None,
+                dir_total_code,
+                None,
+            )
+        )
     matrix.append(
         analyze(
             "TOTAL",

--- a/mkwutil/sections.py
+++ b/mkwutil/sections.py
@@ -60,3 +60,23 @@ REL_SECTIONS = [
 
 # Maps virtual REL section indexes to REL sections in file.
 REL_SECTION_IDX = [1, 2, 3, 4, 5, 6]
+
+REL_DIRS = [
+    Slice(name="REL/JMAP", start=0x80510B84, stop=0x80518CC0, section="text"),
+    Slice(name="REL/SYSTEM", start=0x80518CC0, stop=0x80553788, section="text"),
+    Slice(name="REL/SCENE", start=0x80553788, stop=0x8055531C, section="text"),
+    Slice(name="REL/KART", start=0x805672CC, stop=0x805B9010, section="text"),
+    Slice(name="REL/UI", start=0x805B9300, stop=0x80653208, section="text"),
+    Slice(name="REL/NET", start=0x80653208, stop=0x8067B318, section="text"),
+    Slice(name="REL/GEO/0", start=0x8067E280, stop=0x8068CEDC, section="text"),
+    Slice(name="REL/GEO/1", start=0x806B70D0, stop=0x806F62FC, section="text"),
+    Slice(name="REL/SND", start=0x806F62FC, stop=0x8071B808, section="text"),
+    Slice(name="REL/AI", start=0x80725FDC, stop=0x8074BB34, section="text"),
+    Slice(name="REL/GEO/2", start=0x807519C8, stop=0x8077EE80, section="text"),
+    Slice(name="REL/ITEM", start=0x8079754C, stop=0x807BD1D0, section="text"),
+    Slice(name="REL/UI/CTRL", start=0x807E093C, stop=0x807F9278, section="text"),
+    Slice(name="REL/GEO/3", start=0x807F9278, stop=0x8081A690, section="text"),
+    Slice(name="REL/GEO", start=0x8081A690, stop=0x8082F3C8, section="text"),
+    Slice(name="REL/UI/PAGE", start=0x80836B9C, stop=0x8085FFD4, section="text"),
+    Slice(name="REL/GEO/4", start=0x8086AC20, stop=0x8088BE00, section="text"),
+]


### PR DESCRIPTION
Both the ranges and the naming are preliminary and thus feedback is very welcome.

To improve the readability of the graph with many boxes, we should guarantee a certain level of contrast between neighboring boxes, but that's out of scope for this PR.