### PR TITLE
add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+
+  - repo: https://github.com/psf/black
+    rev: 22.1.0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v13.0.1
+    hooks:
+      - id: clang-format
+        args: ["-style=file", "-i"]
+
+  - repo: local
+    hooks:
+      - id: format-symbols
+        name: format_symbols.py
+        entry: 'python -m mkwutil.tools.format_symbols'
+        language: system
+        types: [file]
+        pass_filenames: true
+        files: 'symbols\.txt'

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Every fully understood piece of reverse engineered data has been documented in a
 - DevKitPro (for the ppc-eabi assembler)
 - CodeWarrior compilers (in `tools`)
 - Python 3
-- Place a copy of Mario Kart Wii's PAL binaries: 
+- Place a copy of Mario Kart Wii's PAL binaries:
   - `artifacts/orig/pal/main.dol`
   - `artifacts/orig/pal/StaticR.rel`
 
@@ -93,5 +93,16 @@ The dead-stripping feature can be re-enabled by:
 - Add your new build target to `mkwutil/sources.py`.
 - Run `build.py`.
 
+### pre-commit
+
+This project uses [pre-commit](https://pre-commit.com/) ensure code adheres to formatting rules.
+
+To enable, run:
+
+```
+pre-commit install
+pre-commit run --all-files
+```
+
 ## .rel support
-Most of Mario Kart Wii's game code is located inside a relocatable module (StaticR.rel for release builds). The decompilation builds this. 
+Most of Mario Kart Wii's game code is located inside a relocatable module (StaticR.rel for release builds). The decompilation builds this.


### PR DESCRIPTION
Adds a [pre-commit](https://pre-commit.com/) config that keeps `symbols.txt`, C/C++, and Python sources formatted.

Closes #119 