### PR TITLE
mkwutil: define symbols in asm instead of lcf

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,12 +58,12 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: asm/dol
-          key: asm-dol
+          key: asm-dol-v2
 
       - uses: actions/cache@v2
         with:
           path: asm/rel
-          key: asm-rel
+          key: asm-rel-v2
 
       - name: Build mkw
         shell: bash
@@ -120,12 +120,12 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: asm/dol
-          key: asm-dol
+          key: asm-dol-v2
 
       - uses: actions/cache@v2
         with:
           path: asm/rel
-          key: asm-rel
+          key: asm-rel-v2
 
       - name: Build mkw
         shell: bash

--- a/build.py
+++ b/build.py
@@ -46,6 +46,7 @@ parser.add_argument(
     type=str,
     default=None,
     help="For quick iteration on a single file before we get full incremental builds")
+parser.add_argument("--link_only", action="store_true", help="Link only, don't build")
 args = parser.parse_args()
 # Start by running gen_asm.
 gen_asm(args.regen_asm)
@@ -327,6 +328,8 @@ def compile_sources():
         print(colored('[NOTE] Only compiling sources matching "%s".' % args.single_file, "red"))
         global gSourceQueue
         gSourceQueue = list(filter(lambda x: args.single_file in str(x[0]), gSourceQueue))
+    if args.link_only:
+        gSourceQueue = []
 
     compile_queued_sources()
 
@@ -341,7 +344,7 @@ def compile_sources():
     for asm in asm_files:
         out_o = Path("out") / asm.relative_to("asm").with_suffix(".o")
         # Optimization: Do not assemble ASM files if the target object already exists.
-        if out_o.exists():
+        if not args.regen_asm and out_o.exists():
             continue
         assemble(out_o, asm)
 
@@ -352,8 +355,7 @@ def link_dol(o_files: list[Path]):
     src_lcf_path = Path("pack", "dol.lcf.j2")
     dst_lcf_path = Path("pack", "dol.lcf")
     slices_path = Path("pack", "dol_slices.csv")
-    symbols_path = Path("pack", "symbols.txt")
-    gen_lcf(src_lcf_path, dst_lcf_path, o_files, slices_path, symbols_path)
+    gen_lcf(src_lcf_path, dst_lcf_path, o_files, slices_path)
     # Create dest dir.
     dest_dir = Path("artifacts", "target", "pal")
     dest_dir.mkdir(parents=True, exist_ok=True)
@@ -373,8 +375,7 @@ def link_rel(o_files: list[Path]):
     src_lcf_path = Path("pack", "rel.lcf.j2")
     dst_lcf_path = Path("pack", "rel.lcf")
     slices_path = Path("pack", "rel_slices.csv")
-    symbols_path = Path("pack", "symbols.txt")
-    gen_lcf(src_lcf_path, dst_lcf_path, o_files, slices_path, symbols_path)
+    gen_lcf(src_lcf_path, dst_lcf_path, o_files, slices_path)
     # Create dest dir.
     dest_dir = Path("artifacts", "target", "pal")
     dest_dir.mkdir(parents=True, exist_ok=True)

--- a/mkwutil/lib/ppc_dis.py
+++ b/mkwutil/lib/ppc_dis.py
@@ -293,7 +293,10 @@ def insn_to_text(insn, raw):
         elif idx in {56, 57, 60, 61}:
             asm = disasm_ps_mem(raw, idx)
     if asm is None:
-        asm = ".4byte 0x%08X  /* unknown instruction */" % raw
+        if raw == 0:
+            asm = ".4byte 0"
+        else:
+            asm = ".4byte 0x%08X  /* unknown instruction */" % raw
     return asm
 
 

--- a/tests/test_slices.py
+++ b/tests/test_slices.py
@@ -164,3 +164,18 @@ def test_slice_table_copy():
   { 00000002..00000004 slice2 }
   { 00000004..00000006 }
 ]"""
+
+def test_slice_split():
+    s = Slice(0, 10)
+    slices = list(s.split([3, 6, 9, 11]))
+    slices = [str(s) for s in slices]
+    assert slices == [
+        "{ 00000000..00000003 }",
+        "{ 00000003..00000006 }",
+        "{ 00000006..00000009 }",
+        "{ 00000009..0000000a }",
+    ]
+
+def test_splice_split2():
+    s = Slice(start=0x802a4080, stop=0x802a6968, section="bss")
+    assert next(s.split([0x80005f34])) == s


### PR DESCRIPTION
The linker-generated symbols from LCF very suc because they lose against weak functions from object files. Thus, just move all symbols to object files via ASM `.global` directives.