### PR TITLE
remove useless comment

### DIFF
--- a/mkwutil/gen_asm/source.c.j2
+++ b/mkwutil/gen_asm/source.c.j2
@@ -11,7 +11,6 @@ extern UNKNOWN_FUNCTION({{ function.name }});
 
 {% for function in functions -%}
 // Symbol: {{ function.name }}
-// Function signature is unknown.
 // PAL: {{ function.addr | addr }}..{{ (function.addr+function.size) | addr }}
 MARK_BINARY_BLOB({{ function.name }}, {{ function.addr | addr }}, {{ (function.addr+function.size) | addr }});
 asm UNKNOWN_FUNCTION({{ function.name }}) {

--- a/source/egg/audio/eggAudioArcPlayerMgr.cpp
+++ b/source/egg/audio/eggAudioArcPlayerMgr.cpp
@@ -182,7 +182,6 @@ lbl_802106b0:
 
 extern "C" {
 
-// Function signature is unknown.
 // PAL: 0x802106b8..0x80210748
 MARK_BINARY_BLOB(unk_802106b8, 0x802106b8, 0x80210748);
 asm UNKNOWN_FUNCTION(unk_802106b8) {
@@ -231,7 +230,6 @@ lbl_80210734:
   // clang-format on
 }
 
-// Function signature is unknown.
 // PAL: 0x80210748..0x802108bc
 MARK_BINARY_BLOB(unk_80210748, 0x80210748, 0x802108bc);
 asm UNKNOWN_FUNCTION(unk_80210748) {
@@ -339,7 +337,6 @@ lbl_802108a8:
   // clang-format on
 }
 
-// Function signature is unknown.
 // PAL: 0x802108bc..0x80210a30
 MARK_BINARY_BLOB(unk_802108bc, 0x802108bc, 0x80210a30);
 asm UNKNOWN_FUNCTION(unk_802108bc) {
@@ -447,7 +444,6 @@ lbl_80210a1c:
   // clang-format on
 }
 
-// Function signature is unknown.
 // PAL: 0x80210a30..0x80210bd8
 MARK_BINARY_BLOB(unk_80210a30, 0x80210a30, 0x80210bd8);
 asm UNKNOWN_FUNCTION(unk_80210a30) {
@@ -567,7 +563,6 @@ lbl_80210bc4:
   // clang-format on
 }
 
-// Function signature is unknown.
 // PAL: 0x80210bd8..0x80210ce4
 MARK_BINARY_BLOB(unk_80210bd8, 0x80210bd8, 0x80210ce4);
 asm UNKNOWN_FUNCTION(unk_80210bd8) {
@@ -648,7 +643,6 @@ lbl_80210cd0:
   // clang-format on
 }
 
-// Function signature is unknown.
 // PAL: 0x80210ce4..0x80210a30
 MARK_BINARY_BLOB(unk_80210ce4, 0x80210ce4, 0x80210d70);
 asm UNKNOWN_FUNCTION(unk_80210ce4) {
@@ -697,7 +691,6 @@ lbl_80210d5c:
   // clang-format on
 }
 
-// Function signature is unknown.
 // PAL: 0x80210d70..0x80210e3c
 MARK_BINARY_BLOB(unk_80210d70, 0x80210d70, 0x80210e3c);
 asm UNKNOWN_FUNCTION(unk_80210d70) {
@@ -762,7 +755,6 @@ lbl_80210e1c:
   // clang-format on
 }
 
-// Function signature is unknown.
 // PAL: 0x80210e3c..0x80210f08
 MARK_BINARY_BLOB(unk_80210e3c, 0x80210e3c, 0x80210f08);
 asm UNKNOWN_FUNCTION(unk_80210e3c) {
@@ -827,7 +819,6 @@ lbl_80210ee8:
   // clang-format on
 }
 
-// Function signature is unknown.
 // PAL: 0x80210f08..0x80210fd4
 MARK_BINARY_BLOB(unk_80210f08, 0x80210f08, 0x80210fd4);
 asm UNKNOWN_FUNCTION(unk_80210f08) {
@@ -944,7 +935,6 @@ lbl_80211020:
 
 extern "C" {
 
-// Function signature is unknown.
 // PAL: 0x80211048..0x80211058
 MARK_BINARY_BLOB(unk_80211048, 0x80211048, 0x80211058);
 asm UNKNOWN_FUNCTION(unk_80211048) {

--- a/source/egg/core/eggAsyncDisplay.cpp
+++ b/source/egg/core/eggAsyncDisplay.cpp
@@ -92,7 +92,6 @@ extern "C" UNKNOWN_FUNCTION(setNextFrameBuffer__Q23EGG10XfbManagerFv);
 extern "C" UNKNOWN_FUNCTION(postVRetrace__Q23EGG10XfbManagerFv);
 
 // Symbol: PostRetraceCallback
-// Function signature is unknown.
 // PAL: 0x8020fcd4..0x8020fcdc
 MARK_BINARY_BLOB(PostRetraceCallback, 0x8020fcd4, 0x8020fcdc);
 asm UNKNOWN_FUNCTION(PostRetraceCallback) {
@@ -104,7 +103,6 @@ asm UNKNOWN_FUNCTION(PostRetraceCallback) {
 }
 
 // Symbol: DrawDoneCallback
-// Function signature is unknown.
 // PAL: 0x8020fcdc..0x8020fd10
 MARK_BINARY_BLOB(DrawDoneCallback, 0x8020fcdc, 0x8020fd10);
 asm UNKNOWN_FUNCTION(DrawDoneCallback) {
@@ -127,7 +125,6 @@ asm UNKNOWN_FUNCTION(DrawDoneCallback) {
 }
 
 // Symbol: AlarmHandler_0
-// Function signature is unknown.
 // PAL: 0x8020fd10..0x8020fd18
 MARK_BINARY_BLOB(AlarmHandler_0, 0x8020fd10, 0x8020fd18);
 asm UNKNOWN_FUNCTION(AlarmHandler_0) {
@@ -139,7 +136,6 @@ asm UNKNOWN_FUNCTION(AlarmHandler_0) {
 }
 
 // Symbol: __ct__Q23EGG12AsyncDisplayFUc
-// Function signature is unknown.
 // PAL: 0x8020fd18..0x8020fd8c
 MARK_BINARY_BLOB(__ct__Q23EGG12AsyncDisplayFUc, 0x8020fd18, 0x8020fd8c);
 asm UNKNOWN_FUNCTION(__ct__Q23EGG12AsyncDisplayFUc) {
@@ -178,7 +174,6 @@ asm UNKNOWN_FUNCTION(__ct__Q23EGG12AsyncDisplayFUc) {
 }
 
 // Symbol: startSyncNTSC__Q23EGG12AsyncDisplayFUc
-// Function signature is unknown.
 // PAL: 0x8020fd8c..0x8020fe24
 MARK_BINARY_BLOB(startSyncNTSC__Q23EGG12AsyncDisplayFUc, 0x8020fd8c,
                  0x8020fe24);
@@ -228,7 +223,6 @@ lbl_8020fe00:
 }
 
 // Symbol: beginFrame__Q23EGG12AsyncDisplayFv
-// Function signature is unknown.
 // PAL: 0x8020fe24..0x8020ff98
 MARK_BINARY_BLOB(beginFrame__Q23EGG12AsyncDisplayFv, 0x8020fe24, 0x8020ff98);
 asm UNKNOWN_FUNCTION(beginFrame__Q23EGG12AsyncDisplayFv) {
@@ -339,7 +333,6 @@ lbl_8020ff74:
 }
 
 // Symbol: beginRender__Q23EGG12AsyncDisplayFv
-// Function signature is unknown.
 // PAL: 0x8020ff98..0x8020ff9c
 MARK_BINARY_BLOB(beginRender__Q23EGG12AsyncDisplayFv, 0x8020ff98, 0x8020ff9c);
 asm UNKNOWN_FUNCTION(beginRender__Q23EGG12AsyncDisplayFv) {
@@ -350,7 +343,6 @@ asm UNKNOWN_FUNCTION(beginRender__Q23EGG12AsyncDisplayFv) {
 }
 
 // Symbol: endRender__Q23EGG12AsyncDisplayFv
-// Function signature is unknown.
 // PAL: 0x8020ff9c..0x80210024
 MARK_BINARY_BLOB(endRender__Q23EGG12AsyncDisplayFv, 0x8020ff9c, 0x80210024);
 asm UNKNOWN_FUNCTION(endRender__Q23EGG12AsyncDisplayFv) {
@@ -397,7 +389,6 @@ lbl_80210010:
 }
 
 // Symbol: postVRetrace__Q23EGG12AsyncDisplayFv
-// Function signature is unknown.
 // PAL: 0x80210024..0x8021008c
 MARK_BINARY_BLOB(postVRetrace__Q23EGG12AsyncDisplayFv, 0x80210024, 0x8021008c);
 asm UNKNOWN_FUNCTION(postVRetrace__Q23EGG12AsyncDisplayFv) {
@@ -434,7 +425,6 @@ lbl_80210078:
 }
 
 // Symbol: alarmHandler__Q23EGG12AsyncDisplayFv
-// Function signature is unknown.
 // PAL: 0x8021008c..0x802100a0
 MARK_BINARY_BLOB(alarmHandler__Q23EGG12AsyncDisplayFv, 0x8021008c, 0x802100a0);
 asm UNKNOWN_FUNCTION(alarmHandler__Q23EGG12AsyncDisplayFv) {
@@ -449,7 +439,6 @@ asm UNKNOWN_FUNCTION(alarmHandler__Q23EGG12AsyncDisplayFv) {
 }
 
 // Symbol: clearEFB__Q23EGG12AsyncDisplayFv
-// Function signature is unknown.
 // PAL: 0x802100a0..0x80210124
 MARK_BINARY_BLOB(clearEFB__Q23EGG12AsyncDisplayFv, 0x802100a0, 0x80210124);
 asm UNKNOWN_FUNCTION(clearEFB__Q23EGG12AsyncDisplayFv) {
@@ -492,7 +481,6 @@ asm UNKNOWN_FUNCTION(clearEFB__Q23EGG12AsyncDisplayFv) {
 }
 
 // Symbol: getTickPerFrame__Q23EGG12AsyncDisplayFv
-// Function signature is unknown.
 // PAL: 0x80210124..0x8021013c
 MARK_BINARY_BLOB(getTickPerFrame__Q23EGG12AsyncDisplayFv, 0x80210124,
                  0x8021013c);
@@ -510,7 +498,6 @@ lbl_80210138:
 }
 
 // Symbol: clearEFB__Q23EGG12AsyncDisplayFUsUsUsUsUsUsQ34nw4r2ut5Color
-// Function signature is unknown.
 // PAL: 0x8021013c..0x802104ec
 MARK_BINARY_BLOB(clearEFB__Q23EGG12AsyncDisplayFUsUsUsUsUsUsQ34nw4r2ut5Color,
                  0x8021013c, 0x802104ec);

--- a/source/egg/core/eggViewport.cpp
+++ b/source/egg/core/eggViewport.cpp
@@ -5,7 +5,6 @@
 extern "C" UNKNOWN_FUNCTION(__ct__Q23EGG10BoundBox2fFv);
 
 // Symbol: __ct__Q23EGG8ViewportFv
-// Function signature is unknown.
 // PAL: 0x80244074..0x802440b4
 MARK_BINARY_BLOB(__ct__Q23EGG8ViewportFv, 0x80244074, 0x802440b4);
 asm UNKNOWN_FUNCTION(__ct__Q23EGG8ViewportFv) {
@@ -33,7 +32,6 @@ asm UNKNOWN_FUNCTION(__ct__Q23EGG8ViewportFv) {
 extern "C" void eggViewport_Calc_TODO();
 
 // Symbol: set__Q23EGG8ViewportFiiii
-// Function signature is unknown.
 // PAL: 0x802440b4..0x80244134
 MARK_BINARY_BLOB(set__Q23EGG8ViewportFiiii, 0x802440b4, 0x80244134);
 asm UNKNOWN_FUNCTION(set__Q23EGG8ViewportFiiii) {
@@ -75,7 +73,6 @@ asm UNKNOWN_FUNCTION(set__Q23EGG8ViewportFiiii) {
 }
 
 // Symbol: eggViewport_Calc_TODO
-// Function signature is unknown.
 // PAL: 0x80244134..0x80244160
 MARK_BINARY_BLOB(eggViewport_Calc_TODO, 0x80244134, 0x80244160);
 asm UNKNOWN_FUNCTION(eggViewport_Calc_TODO) {

--- a/source/egg/core/eggXfb.cpp
+++ b/source/egg/core/eggXfb.cpp
@@ -5,7 +5,6 @@
 extern "C" UNKNOWN_FUNCTION(__nwa__FUlPQ23EGG4Heapi);
 
 // Symbol: __ct__Q23EGG3XfbFPQ23EGG4Heap
-// Function signature is unknown.
 // PAL: 0x80244160..0x802441ec
 MARK_BINARY_BLOB(__ct__Q23EGG3XfbFPQ23EGG4Heap, 0x80244160, 0x802441ec);
 asm UNKNOWN_FUNCTION(__ct__Q23EGG3XfbFPQ23EGG4Heap) {
@@ -51,7 +50,6 @@ lbl_802441b4:
 }
 
 // Symbol: EGG__Xfb__CalcXfbSize
-// Function signature is unknown.
 // PAL: 0x802441ec..0x80244200
 MARK_BINARY_BLOB(EGG__Xfb__CalcXfbSize, 0x802441ec, 0x80244200);
 asm UNKNOWN_FUNCTION(EGG__Xfb__CalcXfbSize) {

--- a/source/egg/core/eggXfbManager.cpp
+++ b/source/egg/core/eggXfbManager.cpp
@@ -23,7 +23,6 @@ extern "C" UNKNOWN_FUNCTION(VISetNextFrameBuffer);
 extern "C" UNKNOWN_FUNCTION(VIGetNextFrameBuffer);
 
 // Symbol: attach__Q23EGG10XfbManagerFPQ23EGG3Xfb
-// Function signature is unknown.
 // PAL: 0x80244200..0x80244268
 MARK_BINARY_BLOB(attach__Q23EGG10XfbManagerFPQ23EGG3Xfb, 0x80244200,
                  0x80244268);
@@ -63,7 +62,6 @@ lbl_80244260:
 }
 
 // Symbol: copyEFB__Q23EGG10XfbManagerFb
-// Function signature is unknown.
 // PAL: 0x80244268..0x802442e8
 MARK_BINARY_BLOB(copyEFB__Q23EGG10XfbManagerFb, 0x80244268, 0x802442e8);
 asm UNKNOWN_FUNCTION(copyEFB__Q23EGG10XfbManagerFb) {
@@ -106,7 +104,6 @@ lbl_802442ac:
 }
 
 // Symbol: setNextFrameBuffer__Q23EGG10XfbManagerFv
-// Function signature is unknown.
 // PAL: 0x802442e8..0x80244350
 MARK_BINARY_BLOB(setNextFrameBuffer__Q23EGG10XfbManagerFv, 0x802442e8,
                  0x80244350);
@@ -144,7 +141,6 @@ lbl_80244330:
 }
 
 // Symbol: postVRetrace__Q23EGG10XfbManagerFv
-// Function signature is unknown.
 // PAL: 0x80244350..0x802443ac
 MARK_BINARY_BLOB(postVRetrace__Q23EGG10XfbManagerFv, 0x80244350, 0x802443ac);
 asm UNKNOWN_FUNCTION(postVRetrace__Q23EGG10XfbManagerFv) {

--- a/source/egg/math/eggQuat.cpp
+++ b/source/egg/math/eggQuat.cpp
@@ -785,7 +785,6 @@ lbl_8023a6f0:
 }
 
 // Symbol: makeVectorRotation__Q23EGG5QuatfFRQ23EGG8Vector3fRQ23EGG8Vector3f
-// Function signature is unknown.
 // PAL: 0x8023a788..0x8023a884
 MARK_BINARY_BLOB(
     makeVectorRotation__Q23EGG5QuatfFRQ23EGG8Vector3fRQ23EGG8Vector3f,

--- a/source/game/system/GhostFile.cpp
+++ b/source/game/system/GhostFile.cpp
@@ -629,7 +629,6 @@ lbl_8051ce60:
 }
 
 // Symbol: Controller_vf10
-// Function signature is unknown.
 // PAL: 0x8051ce7c..0x8051ce84
 MARK_BINARY_BLOB(Controller_vf10, 0x8051ce7c, 0x8051ce84);
 asm UNKNOWN_FUNCTION(Controller_vf10) {
@@ -641,7 +640,6 @@ asm UNKNOWN_FUNCTION(Controller_vf10) {
 }
 
 // Symbol: Input_vf18
-// Function signature is unknown.
 // PAL: 0x8051ce84..0x8051ce8c
 MARK_BINARY_BLOB(Input_vf18, 0x8051ce84, 0x8051ce8c);
 asm UNKNOWN_FUNCTION(Input_vf18) {
@@ -653,7 +651,6 @@ asm UNKNOWN_FUNCTION(Input_vf18) {
 }
 
 // Symbol: Input_vf1c
-// Function signature is unknown.
 // PAL: 0x8051ce8c..0x8051ce94
 MARK_BINARY_BLOB(Input_vf1c, 0x8051ce8c, 0x8051ce94);
 asm UNKNOWN_FUNCTION(Input_vf1c) {

--- a/source/nw4r/ut/ut_CharStrmReader.cpp
+++ b/source/nw4r/ut/ut_CharStrmReader.cpp
@@ -6,7 +6,6 @@ namespace nw4r {
 namespace ut {
 
 // Symbol: ReadNextCharUTF8__Q34nw4r2ut14CharStrmReaderFv
-// Function signature is unknown.
 // PAL: 0x800af420..0x800af4a0
 MARK_BINARY_BLOB(ReadNextCharUTF8__Q34nw4r2ut14CharStrmReaderFv, 0x800af420,
                  0x800af4a0);
@@ -50,7 +49,6 @@ lbl_800af490:
 }
 
 // Symbol: ReadNextCharUTF16__Q34nw4r2ut14CharStrmReaderFv
-// Function signature is unknown.
 // PAL: 0x800af4a0..0x800af4c0
 MARK_BINARY_BLOB(ReadNextCharUTF16__Q34nw4r2ut14CharStrmReaderFv, 0x800af4a0,
                  0x800af4c0);
@@ -68,7 +66,6 @@ asm u16 CharStrmReader::ReadNextCharUTF16() {
 }
 
 // Symbol: ReadNextCharCP1252__Q34nw4r2ut14CharStrmReaderFv
-// Function signature is unknown.
 // PAL: 0x800af4c0..0x800af4e0
 MARK_BINARY_BLOB(ReadNextCharCP1252__Q34nw4r2ut14CharStrmReaderFv, 0x800af4c0,
                  0x800af4e0);
@@ -86,7 +83,6 @@ asm u16 CharStrmReader::ReadNextCharCP1252() {
 }
 
 // Symbol: ReadNextCharSJIS__Q34nw4r2ut14CharStrmReaderFv
-// Function signature is unknown.
 // PAL: 0x800af4e0..0x800af540
 MARK_BINARY_BLOB(ReadNextCharSJIS__Q34nw4r2ut14CharStrmReaderFv, 0x800af4e0,
                  0x800af540);

--- a/source/nw4r/ut/ut_LinkList.cpp
+++ b/source/nw4r/ut/ut_LinkList.cpp
@@ -5,7 +5,6 @@
 extern UNKNOWN_FUNCTION(__dl__FPv);
 
 // Symbol: __dt__Q44nw4r2ut6detail12LinkListImplFv
-// Function signature is unknown.
 // PAL: 0x800af210..0x800af2a0
 MARK_BINARY_BLOB(__dt__Q44nw4r2ut6detail12LinkListImplFv, 0x800af210,
                  0x800af2a0);
@@ -53,7 +52,6 @@ lbl_800af27c:
 
 // Symbol:
 // Erase__Q44nw4r2ut6detail12LinkListImplFQ54nw4r2ut6detail12LinkListImpl8Iterator
-// Function signature is unknown.
 // PAL: 0x800af2a0..0x800af2f0
 MARK_BINARY_BLOB(
     Erase__Q44nw4r2ut6detail12LinkListImplFQ54nw4r2ut6detail12LinkListImpl8Iterator,
@@ -86,7 +84,6 @@ lbl_800af2d8:
 }
 
 // Symbol: Clear__Q44nw4r2ut6detail12LinkListImplFv
-// Function signature is unknown.
 // PAL: 0x800af2f0..0x800af340
 MARK_BINARY_BLOB(Clear__Q44nw4r2ut6detail12LinkListImplFv, 0x800af2f0,
                  0x800af340);
@@ -117,7 +114,6 @@ lbl_800af328:
 
 // Symbol:
 // Insert__Q44nw4r2ut6detail12LinkListImplFQ54nw4r2ut6detail12LinkListImpl8IteratorPQ34nw4r2ut12LinkListNode
-// Function signature is unknown.
 // PAL: 0x800af340..0x800af370
 MARK_BINARY_BLOB(
     Insert__Q44nw4r2ut6detail12LinkListImplFQ54nw4r2ut6detail12LinkListImpl8IteratorPQ34nw4r2ut12LinkListNode,
@@ -141,7 +137,6 @@ asm UNKNOWN_FUNCTION(
 }
 
 // Symbol: Erase__Q44nw4r2ut6detail12LinkListImplFPQ34nw4r2ut12LinkListNode
-// Function signature is unknown.
 // PAL: 0x800af370..0x800af3a0
 MARK_BINARY_BLOB(
     Erase__Q44nw4r2ut6detail12LinkListImplFPQ34nw4r2ut12LinkListNode,

--- a/source/nw4r/ut/ut_binaryFileFormat.cpp
+++ b/source/nw4r/ut/ut_binaryFileFormat.cpp
@@ -1,7 +1,6 @@
 #include "ut_binaryFileFormat.hpp"
 
 // Symbol: IsValidBinaryFile__Q24nw4r2utFPCQ34nw4r2ut16BinaryFileHeaderUlUsUs
-// Function signature is unknown.
 // PAL: 0x800af3a0..0x800af420
 MARK_BINARY_BLOB(
     IsValidBinaryFile__Q24nw4r2utFPCQ34nw4r2ut16BinaryFileHeaderUlUsUs,

--- a/source/nw4r/ut/ut_resFontBase.cpp
+++ b/source/nw4r/ut/ut_resFontBase.cpp
@@ -94,7 +94,6 @@ asm int ResFontBase::GetWidth() const {
 }
 
 // Symbol: GetHeight__Q44nw4r2ut6detail11ResFontBaseCFv
-// Function signature is unknown.
 // PAL: 0x800b2050..0x800b2060
 MARK_BINARY_BLOB(GetHeight__Q44nw4r2ut6detail11ResFontBaseCFv, 0x800b2050,
                  0x800b2060);

--- a/source/platform/ansi_files.c
+++ b/source/platform/ansi_files.c
@@ -63,7 +63,6 @@ lbl_8000c9c8:
 }
 
 // Symbol: __flush_line_buffered_output_files
-// Function signature is unknown.
 // PAL: 0x8000c9ec..0x8000ca70
 MARK_BINARY_BLOB(__flush_line_buffered_output_files, 0x8000c9ec, 0x8000ca70);
 asm int __flush_line_buffered_output_files(void) {
@@ -109,7 +108,6 @@ lbl_8000ca4c:
 }
 
 // Symbol: __flush_all
-// Function signature is unknown.
 // PAL: 0x8000ca70..0x8000cadc
 MARK_BINARY_BLOB(__flush_all, 0x8000ca70, 0x8000cadc);
 asm int __flush_all(void) {

--- a/source/platform/ansi_fp.c
+++ b/source/platform/ansi_fp.c
@@ -3,7 +3,6 @@
 #include <math.h>
 
 // Symbol: __ull2dec
-// Function signature is unknown.
 // PAL: 0x8000cadc..0x8000cbb8
 MARK_BINARY_BLOB(__ull2dec, 0x8000cadc, 0x8000cbb8);
 asm UNKNOWN_FUNCTION(__ull2dec) {
@@ -72,7 +71,6 @@ lbl_8000cb84:
 }
 
 // Symbol: __timesdec
-// Function signature is unknown.
 // PAL: 0x8000cbb8..0x8000ce40
 MARK_BINARY_BLOB(__timesdec, 0x8000cbb8, 0x8000ce40);
 asm UNKNOWN_FUNCTION(__timesdec) {
@@ -263,7 +261,6 @@ lbl_8000ce2c:
 }
 
 // Symbol: __str2dec
-// Function signature is unknown.
 // PAL: 0x8000ce40..0x8000cf2c
 MARK_BINARY_BLOB(__str2dec, 0x8000ce40, 0x8000cf2c);
 asm UNKNOWN_FUNCTION(__str2dec) {
@@ -341,7 +338,6 @@ lbl_8000cf1c:
 }
 
 // Symbol: __two_exp
-// Function signature is unknown.
 // PAL: 0x8000cf2c..0x8000d298
 MARK_BINARY_BLOB(__two_exp, 0x8000cf2c, 0x8000d298);
 asm UNKNOWN_FUNCTION(__two_exp) {
@@ -575,7 +571,6 @@ lbl_8000d280:
 }
 
 // Symbol: __equals_dec
-// Function signature is unknown.
 // PAL: 0x8000d298..0x8000d37c
 MARK_BINARY_BLOB(__equals_dec, 0x8000d298, 0x8000d37c);
 asm UNKNOWN_FUNCTION(__equals_dec) {
@@ -653,7 +648,6 @@ lbl_8000d374:
 }
 
 // Symbol: __less_dec
-// Function signature is unknown.
 // PAL: 0x8000d37c..0x8000d47c
 MARK_BINARY_BLOB(__less_dec, 0x8000d37c, 0x8000d47c);
 asm UNKNOWN_FUNCTION(__less_dec) {
@@ -738,7 +732,6 @@ lbl_8000d464:
 }
 
 // Symbol: __minus_dec
-// Function signature is unknown.
 // PAL: 0x8000d47c..0x8000d998
 MARK_BINARY_BLOB(__minus_dec, 0x8000d47c, 0x8000d998);
 asm UNKNOWN_FUNCTION(__minus_dec) {
@@ -1110,7 +1103,6 @@ lbl_8000d98c:
 }
 
 // Symbol: __num2dec_internal
-// Function signature is unknown.
 // PAL: 0x8000d998..0x8000dafc
 MARK_BINARY_BLOB(__num2dec_internal, 0x8000d998, 0x8000dafc);
 asm UNKNOWN_FUNCTION(__num2dec_internal) {
@@ -1215,7 +1207,6 @@ lbl_8000dadc:
 }
 
 // Symbol: __num2dec
-// Function signature is unknown.
 // PAL: 0x8000dafc..0x8000dc9c
 MARK_BINARY_BLOB(__num2dec, 0x8000dafc, 0x8000dc9c);
 asm UNKNOWN_FUNCTION(__num2dec) {
@@ -1345,7 +1336,6 @@ lbl_8000dc84:
 }
 
 // Symbol: __dec2num
-// Function signature is unknown.
 // PAL: 0x8000dc9c..0x8000e418
 MARK_BINARY_BLOB(__dec2num, 0x8000dc9c, 0x8000e418);
 asm UNKNOWN_FUNCTION(__dec2num) {

--- a/source/platform/float.c
+++ b/source/platform/float.c
@@ -3,7 +3,6 @@
 #include <decomp.h>
 
 // Symbol: __fpclassifyf
-// Function signature is unknown.
 // PAL: 0x8000ef04..0x8000ef64
 MARK_BINARY_BLOB(__fpclassifyf, 0x8000ef04, 0x8000ef64);
 asm UNKNOWN_FUNCTION(__fpclassifyf) {
@@ -41,7 +40,6 @@ lbl_8000ef5c:
 }
 
 // Symbol: __signbitd
-// Function signature is unknown.
 // PAL: 0x8000ef64..0x8000ef7c
 MARK_BINARY_BLOB(__signbitd, 0x8000ef64, 0x8000ef7c);
 asm UNKNOWN_FUNCTION(__signbitd) {

--- a/source/platform/mem_cpy.c
+++ b/source/platform/mem_cpy.c
@@ -1,7 +1,6 @@
 #include "mem_cpy.h"
 
 // Symbol: __copy_longs_aligned
-// Function signature is unknown.
 // PAL: 0x8000f360..0x8000f41c
 MARK_BINARY_BLOB(__copy_longs_aligned, 0x8000f360, 0x8000f41c);
 asm UNKNOWN_FUNCTION(__copy_longs_aligned) {
@@ -65,7 +64,6 @@ lbl_8000f408:
 }
 
 // Symbol: __copy_longs_rev_aligned
-// Function signature is unknown.
 // PAL: 0x8000f41c..0x8000f4c4
 MARK_BINARY_BLOB(__copy_longs_rev_aligned, 0x8000f41c, 0x8000f4c4);
 asm UNKNOWN_FUNCTION(__copy_longs_rev_aligned) {
@@ -124,7 +122,6 @@ lbl_8000f4b0:
 }
 
 // Symbol: __copy_longs_unaligned
-// Function signature is unknown.
 // PAL: 0x8000f4c4..0x8000f584
 MARK_BINARY_BLOB(__copy_longs_unaligned, 0x8000f4c4, 0x8000f584);
 asm UNKNOWN_FUNCTION(__copy_longs_unaligned) {
@@ -187,7 +184,6 @@ lbl_8000f570:
 }
 
 // Symbol: __copy_longs_rev_unaligned
-// Function signature is unknown.
 // PAL: 0x8000f584..0x8000f630
 MARK_BINARY_BLOB(__copy_longs_rev_unaligned, 0x8000f584, 0x8000f630);
 asm UNKNOWN_FUNCTION(__copy_longs_rev_unaligned) {

--- a/source/platform/printf.c
+++ b/source/platform/printf.c
@@ -22,7 +22,6 @@ extern UNKNOWN_FUNCTION(raise);
 extern UNKNOWN_FUNCTION(fwide);
 
 // Symbol: double2hex
-// Function signature is unknown.
 // PAL: 0x800100e4..0x800104b4
 MARK_BINARY_BLOB(double2hex, 0x800100e4, 0x800104b4);
 asm UNKNOWN_FUNCTION(double2hex) {
@@ -307,7 +306,6 @@ lbl_8001048c:
 }
 
 // Symbol: round_decimal
-// Function signature is unknown.
 // PAL: 0x800104b4..0x800105dc
 MARK_BINARY_BLOB(round_decimal, 0x800104b4, 0x800105dc);
 asm UNKNOWN_FUNCTION(round_decimal) {
@@ -404,7 +402,6 @@ lbl_800105cc:
 }
 
 // Symbol: float2str
-// Function signature is unknown.
 // PAL: 0x800105dc..0x80010d74
 MARK_BINARY_BLOB(float2str, 0x800105dc, 0x80010d74);
 asm UNKNOWN_FUNCTION(float2str) {
@@ -978,7 +975,6 @@ lbl_80010d50:
 }
 
 // Symbol: __pformatter
-// Function signature is unknown.
 // PAL: 0x80010d74..0x80011620
 MARK_BINARY_BLOB(__pformatter, 0x80010d74, 0x80011620);
 asm UNKNOWN_FUNCTION(__pformatter) {
@@ -1610,7 +1606,6 @@ lbl_8001160c:
 }
 
 // Symbol: __FileWrite
-// Function signature is unknown.
 // PAL: 0x80011620..0x80011678
 MARK_BINARY_BLOB(__FileWrite, 0x80011620, 0x80011678);
 asm UNKNOWN_FUNCTION(__FileWrite) {
@@ -1644,7 +1639,6 @@ lbl_8001165c:
 }
 
 // Symbol: __StringWrite
-// Function signature is unknown.
 // PAL: 0x80011678..0x800116e4
 MARK_BINARY_BLOB(__StringWrite, 0x80011678, 0x800116e4);
 asm UNKNOWN_FUNCTION(__StringWrite) {
@@ -1682,7 +1676,6 @@ lbl_800116ac:
 }
 
 // Symbol: printf
-// Function signature is unknown.
 // PAL: 0x800116e4..0x800117b0
 MARK_BINARY_BLOB(printf, 0x800116e4, 0x800117b0);
 asm UNKNOWN_FUNCTION(printf) {
@@ -1746,7 +1739,6 @@ lbl_80011798:
 }
 
 // Symbol: vprintf
-// Function signature is unknown.
 // PAL: 0x800117b0..0x8001182c
 MARK_BINARY_BLOB(vprintf, 0x800117b0, 0x8001182c);
 asm int vprintf(const char* format, va_list arg) {

--- a/source/platform/scanf.c
+++ b/source/platform/scanf.c
@@ -20,7 +20,6 @@ UNKNOWN_FUNCTION(__sformatter);
 UNKNOWN_FUNCTION(__StringRead);
 
 // Symbol: parse_format
-// Function signature is unknown.
 // PAL: 0x80011c98..0x80012320
 MARK_BINARY_BLOB(parse_format, 0x80011c98, 0x80012320);
 asm UNKNOWN_FUNCTION(parse_format) {
@@ -488,7 +487,6 @@ lbl_80012310:
 }
 
 // Symbol: __sformatter
-// Function signature is unknown.
 // PAL: 0x80012320..0x80012fb8
 MARK_BINARY_BLOB(__sformatter, 0x80012320, 0x80012fb8);
 asm UNKNOWN_FUNCTION(__sformatter) {
@@ -1409,7 +1407,6 @@ lbl_80012fa0:
 }
 
 // Symbol: __StringRead
-// Function signature is unknown.
 // PAL: 0x80012fb8..0x80013040
 MARK_BINARY_BLOB(__StringRead, 0x80012fb8, 0x80013040);
 asm UNKNOWN_FUNCTION(__StringRead) {

--- a/source/platform/va_arg.c
+++ b/source/platform/va_arg.c
@@ -1,7 +1,6 @@
 #include "va_arg.h"
 
 // Symbol: __va_arg
-// Function signature is unknown.
 // PAL: 0x80021270..0x80021338
 MARK_BINARY_BLOB(__va_arg, 0x80021270, 0x80021338);
 asm UNKNOWN_FUNCTION(__va_arg) {

--- a/source/rfl/rfl_init.c
+++ b/source/rfl/rfl_init.c
@@ -31,7 +31,6 @@ extern UNKNOWN_FUNCTION(unk_800c6700);
 extern UNKNOWN_FUNCTION(unk_800c7ee0);
 
 // Symbol: RFLGetWorkSize
-// Function signature is unknown.
 // PAL: 0x800bbb80..0x800bbba0
 MARK_BINARY_BLOB(RFLGetWorkSize, 0x800bbb80, 0x800bbba0);
 asm UNKNOWN_FUNCTION(RFLGetWorkSize) {
@@ -48,7 +47,6 @@ asm UNKNOWN_FUNCTION(RFLGetWorkSize) {
 }
 
 // Symbol: RFLInitResAsync
-// Function signature is unknown.
 // PAL: 0x800bbba0..0x800bbf08
 MARK_BINARY_BLOB(RFLInitResAsync, 0x800bbba0, 0x800bbf08);
 asm UNKNOWN_FUNCTION(RFLInitResAsync) {

--- a/source/rvl/ax/rvlAx.c
+++ b/source/rvl/ax/rvlAx.c
@@ -22,7 +22,6 @@ char* _unk_803857f8 = _unk_8027e778;
 u32 _unk_80386488;
 
 // Symbol: AXInit
-// Function signature is unknown.
 // PAL: 0x80124e80..0x80124ed4
 MARK_BINARY_BLOB(AXInit, 0x80124e80, 0x80124ed4);
 asm UNKNOWN_FUNCTION(AXInit) {

--- a/source/rvl/ax/rvlAxAlloc.c
+++ b/source/rvl/ax/rvlAxAlloc.c
@@ -12,7 +12,6 @@ u32 _unk_80386490;
 extern UNKNOWN_FUNCTION(__AXSetPBDefault);
 
 // Symbol: __AXGetStackHead
-// Function signature is unknown.
 // PAL: 0x80124edc..0x80124ef0
 MARK_BINARY_BLOB(__AXGetStackHead, 0x80124edc, 0x80124ef0);
 asm UNKNOWN_FUNCTION(__AXGetStackHead) {
@@ -27,7 +26,6 @@ asm UNKNOWN_FUNCTION(__AXGetStackHead) {
 }
 
 // Symbol: __AXServiceCallbackStack
-// Function signature is unknown.
 // PAL: 0x80124ef0..0x80124f9c
 MARK_BINARY_BLOB(__AXServiceCallbackStack, 0x80124ef0, 0x80124f9c);
 asm UNKNOWN_FUNCTION(__AXServiceCallbackStack) {
@@ -85,7 +83,6 @@ lbl_80124f78:
 }
 
 // Symbol: __AXAllocInit
-// Function signature is unknown.
 // PAL: 0x80124f9c..0x8012504c
 MARK_BINARY_BLOB(__AXAllocInit, 0x80124f9c, 0x8012504c);
 asm UNKNOWN_FUNCTION(__AXAllocInit) {
@@ -140,7 +137,6 @@ lbl_80124fbc:
 }
 
 // Symbol: __AXPushFreeStack
-// Function signature is unknown.
 // PAL: 0x8012504c..0x80125068
 MARK_BINARY_BLOB(__AXPushFreeStack, 0x8012504c, 0x80125068);
 asm UNKNOWN_FUNCTION(__AXPushFreeStack) {
@@ -157,7 +153,6 @@ asm UNKNOWN_FUNCTION(__AXPushFreeStack) {
 }
 
 // Symbol: __AXPushCallbackStack
-// Function signature is unknown.
 // PAL: 0x80125068..0x80125078
 MARK_BINARY_BLOB(__AXPushCallbackStack, 0x80125068, 0x80125078);
 asm UNKNOWN_FUNCTION(__AXPushCallbackStack) {
@@ -171,7 +166,6 @@ asm UNKNOWN_FUNCTION(__AXPushCallbackStack) {
 }
 
 // Symbol: __AXRemoveFromStack
-// Function signature is unknown.
 // PAL: 0x80125078..0x801250fc
 MARK_BINARY_BLOB(__AXRemoveFromStack, 0x80125078, 0x801250fc);
 asm UNKNOWN_FUNCTION(__AXRemoveFromStack) {
@@ -217,7 +211,6 @@ lbl_801250e8:
 }
 
 // Symbol: AXFreeVoice
-// Function signature is unknown.
 // PAL: 0x801250fc..0x80125178
 MARK_BINARY_BLOB(AXFreeVoice, 0x801250fc, 0x80125178);
 asm UNKNOWN_FUNCTION(AXFreeVoice) {
@@ -259,7 +252,6 @@ lbl_80125138:
 }
 
 // Symbol: AXAcquireVoice
-// Function signature is unknown.
 // PAL: 0x80125178..0x80125394
 MARK_BINARY_BLOB(AXAcquireVoice, 0x80125178, 0x80125394);
 asm UNKNOWN_FUNCTION(AXAcquireVoice) {

--- a/source/rvl/ax/rvlAxAux.c
+++ b/source/rvl/ax/rvlAxAux.c
@@ -27,7 +27,6 @@ u32 _unk_80386498;
 extern u32 _unk_803864f0;
 
 // Symbol: __AXAuxInit
-// Function signature is unknown.
 // PAL: 0x80125394..0x801254a8
 MARK_BINARY_BLOB(__AXAuxInit, 0x80125394, 0x801254a8);
 asm UNKNOWN_FUNCTION(__AXAuxInit) {
@@ -107,7 +106,6 @@ lbl_801253ec:
 }
 
 // Symbol: __AXGetAuxAInput
-// Function signature is unknown.
 // PAL: 0x801254a8..0x801254dc
 MARK_BINARY_BLOB(__AXGetAuxAInput, 0x801254a8, 0x801254dc);
 asm UNKNOWN_FUNCTION(__AXGetAuxAInput) {
@@ -131,7 +129,6 @@ lbl_801254d0:
 }
 
 // Symbol: __AXGetAuxAOutput
-// Function signature is unknown.
 // PAL: 0x801254dc..0x801254f8
 MARK_BINARY_BLOB(__AXGetAuxAOutput, 0x801254dc, 0x801254f8);
 asm UNKNOWN_FUNCTION(__AXGetAuxAOutput) {
@@ -148,7 +145,6 @@ asm UNKNOWN_FUNCTION(__AXGetAuxAOutput) {
 }
 
 // Symbol: __AXGetAuxAInputDpl2
-// Function signature is unknown.
 // PAL: 0x801254f8..0x80125518
 MARK_BINARY_BLOB(__AXGetAuxAInputDpl2, 0x801254f8, 0x80125518);
 asm UNKNOWN_FUNCTION(__AXGetAuxAInputDpl2) {
@@ -166,7 +162,6 @@ asm UNKNOWN_FUNCTION(__AXGetAuxAInputDpl2) {
 }
 
 // Symbol: __AXGetAuxAOutputDpl2R
-// Function signature is unknown.
 // PAL: 0x80125518..0x80125538
 MARK_BINARY_BLOB(__AXGetAuxAOutputDpl2R, 0x80125518, 0x80125538);
 asm UNKNOWN_FUNCTION(__AXGetAuxAOutputDpl2R) {
@@ -184,7 +179,6 @@ asm UNKNOWN_FUNCTION(__AXGetAuxAOutputDpl2R) {
 }
 
 // Symbol: __AXGetAuxAOutputDpl2Ls
-// Function signature is unknown.
 // PAL: 0x80125538..0x80125558
 MARK_BINARY_BLOB(__AXGetAuxAOutputDpl2Ls, 0x80125538, 0x80125558);
 asm UNKNOWN_FUNCTION(__AXGetAuxAOutputDpl2Ls) {
@@ -202,7 +196,6 @@ asm UNKNOWN_FUNCTION(__AXGetAuxAOutputDpl2Ls) {
 }
 
 // Symbol: __AXGetAuxAOutputDpl2Rs
-// Function signature is unknown.
 // PAL: 0x80125558..0x80125578
 MARK_BINARY_BLOB(__AXGetAuxAOutputDpl2Rs, 0x80125558, 0x80125578);
 asm UNKNOWN_FUNCTION(__AXGetAuxAOutputDpl2Rs) {
@@ -220,7 +213,6 @@ asm UNKNOWN_FUNCTION(__AXGetAuxAOutputDpl2Rs) {
 }
 
 // Symbol: __AXGetAuxBInput
-// Function signature is unknown.
 // PAL: 0x80125578..0x801255ac
 MARK_BINARY_BLOB(__AXGetAuxBInput, 0x80125578, 0x801255ac);
 asm UNKNOWN_FUNCTION(__AXGetAuxBInput) {
@@ -244,7 +236,6 @@ lbl_801255a0:
 }
 
 // Symbol: __AXGetAuxBOutput
-// Function signature is unknown.
 // PAL: 0x801255ac..0x801255c8
 MARK_BINARY_BLOB(__AXGetAuxBOutput, 0x801255ac, 0x801255c8);
 asm UNKNOWN_FUNCTION(__AXGetAuxBOutput) {
@@ -261,7 +252,6 @@ asm UNKNOWN_FUNCTION(__AXGetAuxBOutput) {
 }
 
 // Symbol: __AXGetAuxBInputDpl2
-// Function signature is unknown.
 // PAL: 0x801255c8..0x801255e8
 MARK_BINARY_BLOB(__AXGetAuxBInputDpl2, 0x801255c8, 0x801255e8);
 asm UNKNOWN_FUNCTION(__AXGetAuxBInputDpl2) {
@@ -279,7 +269,6 @@ asm UNKNOWN_FUNCTION(__AXGetAuxBInputDpl2) {
 }
 
 // Symbol: __AXGetAuxBOutputDpl2R
-// Function signature is unknown.
 // PAL: 0x801255e8..0x80125608
 MARK_BINARY_BLOB(__AXGetAuxBOutputDpl2R, 0x801255e8, 0x80125608);
 asm UNKNOWN_FUNCTION(__AXGetAuxBOutputDpl2R) {
@@ -297,7 +286,6 @@ asm UNKNOWN_FUNCTION(__AXGetAuxBOutputDpl2R) {
 }
 
 // Symbol: __AXGetAuxBOutputDpl2Ls
-// Function signature is unknown.
 // PAL: 0x80125608..0x80125628
 MARK_BINARY_BLOB(__AXGetAuxBOutputDpl2Ls, 0x80125608, 0x80125628);
 asm UNKNOWN_FUNCTION(__AXGetAuxBOutputDpl2Ls) {
@@ -315,7 +303,6 @@ asm UNKNOWN_FUNCTION(__AXGetAuxBOutputDpl2Ls) {
 }
 
 // Symbol: __AXGetAuxBOutputDpl2Rs
-// Function signature is unknown.
 // PAL: 0x80125628..0x80125648
 MARK_BINARY_BLOB(__AXGetAuxBOutputDpl2Rs, 0x80125628, 0x80125648);
 asm UNKNOWN_FUNCTION(__AXGetAuxBOutputDpl2Rs) {
@@ -333,7 +320,6 @@ asm UNKNOWN_FUNCTION(__AXGetAuxBOutputDpl2Rs) {
 }
 
 // Symbol: __AXGetAuxCInput
-// Function signature is unknown.
 // PAL: 0x80125648..0x8012567c
 MARK_BINARY_BLOB(__AXGetAuxCInput, 0x80125648, 0x8012567c);
 asm UNKNOWN_FUNCTION(__AXGetAuxCInput) {
@@ -357,7 +343,6 @@ lbl_80125670:
 }
 
 // Symbol: __AXGetAuxCOutput
-// Function signature is unknown.
 // PAL: 0x8012567c..0x80125698
 MARK_BINARY_BLOB(__AXGetAuxCOutput, 0x8012567c, 0x80125698);
 asm UNKNOWN_FUNCTION(__AXGetAuxCOutput) {
@@ -374,7 +359,6 @@ asm UNKNOWN_FUNCTION(__AXGetAuxCOutput) {
 }
 
 // Symbol: __AXProcessAux
-// Function signature is unknown.
 // PAL: 0x80125698..0x80125a44
 MARK_BINARY_BLOB(__AXProcessAux, 0x80125698, 0x80125a44);
 asm UNKNOWN_FUNCTION(__AXProcessAux) {
@@ -627,7 +611,6 @@ lbl_801259cc:
 }
 
 // Symbol: AXRegisterAuxACallback
-// Function signature is unknown.
 // PAL: 0x80125a44..0x80125aa8
 MARK_BINARY_BLOB(AXRegisterAuxACallback, 0x80125a44, 0x80125aa8);
 asm UNKNOWN_FUNCTION(AXRegisterAuxACallback) {
@@ -663,7 +646,6 @@ lbl_80125a88:
 }
 
 // Symbol: AXRegisterAuxBCallback
-// Function signature is unknown.
 // PAL: 0x80125aa8..0x80125b0c
 MARK_BINARY_BLOB(AXRegisterAuxBCallback, 0x80125aa8, 0x80125b0c);
 asm UNKNOWN_FUNCTION(AXRegisterAuxBCallback) {
@@ -699,7 +681,6 @@ lbl_80125aec:
 }
 
 // Symbol: AXRegisterAuxCCallback
-// Function signature is unknown.
 // PAL: 0x80125b0c..0x80125b70
 MARK_BINARY_BLOB(AXRegisterAuxCCallback, 0x80125b0c, 0x80125b70);
 asm UNKNOWN_FUNCTION(AXRegisterAuxCCallback) {
@@ -735,7 +716,6 @@ lbl_80125b50:
 }
 
 // Symbol: AXGetAuxACallback
-// Function signature is unknown.
 // PAL: 0x80125b70..0x80125b84
 MARK_BINARY_BLOB(AXGetAuxACallback, 0x80125b70, 0x80125b84);
 asm UNKNOWN_FUNCTION(AXGetAuxACallback) {
@@ -750,7 +730,6 @@ asm UNKNOWN_FUNCTION(AXGetAuxACallback) {
 }
 
 // Symbol: AXGetAuxBCallback
-// Function signature is unknown.
 // PAL: 0x80125b84..0x80125b98
 MARK_BINARY_BLOB(AXGetAuxBCallback, 0x80125b84, 0x80125b98);
 asm UNKNOWN_FUNCTION(AXGetAuxBCallback) {
@@ -765,7 +744,6 @@ asm UNKNOWN_FUNCTION(AXGetAuxBCallback) {
 }
 
 // Symbol: AXGetAuxCCallback
-// Function signature is unknown.
 // PAL: 0x80125b98..0x80125bac
 MARK_BINARY_BLOB(AXGetAuxCCallback, 0x80125b98, 0x80125bac);
 asm UNKNOWN_FUNCTION(AXGetAuxCCallback) {

--- a/source/rvl/ax/rvlAxCl.c
+++ b/source/rvl/ax/rvlAxCl.c
@@ -23,7 +23,6 @@ u16 _unk_803864e2;
 u16 _unk_803864e0;
 
 // Symbol: __AXGetCommandListCycles
-// Function signature is unknown.
 // PAL: 0x80125bac..0x80125bb4
 MARK_BINARY_BLOB(__AXGetCommandListCycles, 0x80125bac, 0x80125bb4);
 asm UNKNOWN_FUNCTION(__AXGetCommandListCycles) {
@@ -35,7 +34,6 @@ asm UNKNOWN_FUNCTION(__AXGetCommandListCycles) {
 }
 
 // Symbol: __AXGetCommandListAddress
-// Function signature is unknown.
 // PAL: 0x80125bb4..0x80125be4
 MARK_BINARY_BLOB(__AXGetCommandListAddress, 0x80125bb4, 0x80125be4);
 asm UNKNOWN_FUNCTION(__AXGetCommandListAddress) {
@@ -57,7 +55,6 @@ asm UNKNOWN_FUNCTION(__AXGetCommandListAddress) {
 }
 
 // Symbol: __AXNextFrame
-// Function signature is unknown.
 // PAL: 0x80125be4..0x801265a4
 MARK_BINARY_BLOB(__AXNextFrame, 0x80125be4, 0x801265a4);
 asm UNKNOWN_FUNCTION(__AXNextFrame) {
@@ -704,7 +701,6 @@ lbl_80126558:
 }
 
 // Symbol: __AXClInit
-// Function signature is unknown.
 // PAL: 0x801265a4..0x801265e0
 MARK_BINARY_BLOB(__AXClInit, 0x801265a4, 0x801265e0);
 asm UNKNOWN_FUNCTION(__AXClInit) {
@@ -729,7 +725,6 @@ asm UNKNOWN_FUNCTION(__AXClInit) {
 }
 
 // Symbol: AXSetMode
-// Function signature is unknown.
 // PAL: 0x801265e0..0x801265e8
 MARK_BINARY_BLOB(AXSetMode, 0x801265e0, 0x801265e8);
 asm UNKNOWN_FUNCTION(AXSetMode) {
@@ -741,7 +736,6 @@ asm UNKNOWN_FUNCTION(AXSetMode) {
 }
 
 // Symbol: AXGetMode
-// Function signature is unknown.
 // PAL: 0x801265e8..0x801265f0
 MARK_BINARY_BLOB(AXGetMode, 0x801265e8, 0x801265f0);
 asm UNKNOWN_FUNCTION(AXGetMode) {
@@ -753,7 +747,6 @@ asm UNKNOWN_FUNCTION(AXGetMode) {
 }
 
 // Symbol: AXGetAuxAReturnVolume
-// Function signature is unknown.
 // PAL: 0x801265f0..0x801265f8
 MARK_BINARY_BLOB(AXGetAuxAReturnVolume, 0x801265f0, 0x801265f8);
 asm UNKNOWN_FUNCTION(AXGetAuxAReturnVolume) {
@@ -765,7 +758,6 @@ asm UNKNOWN_FUNCTION(AXGetAuxAReturnVolume) {
 }
 
 // Symbol: AXGetAuxBReturnVolume
-// Function signature is unknown.
 // PAL: 0x801265f8..0x80126600
 MARK_BINARY_BLOB(AXGetAuxBReturnVolume, 0x801265f8, 0x80126600);
 asm UNKNOWN_FUNCTION(AXGetAuxBReturnVolume) {
@@ -777,7 +769,6 @@ asm UNKNOWN_FUNCTION(AXGetAuxBReturnVolume) {
 }
 
 // Symbol: AXGetAuxCReturnVolume
-// Function signature is unknown.
 // PAL: 0x80126600..0x80126608
 MARK_BINARY_BLOB(AXGetAuxCReturnVolume, 0x80126600, 0x80126608);
 asm UNKNOWN_FUNCTION(AXGetAuxCReturnVolume) {
@@ -789,7 +780,6 @@ asm UNKNOWN_FUNCTION(AXGetAuxCReturnVolume) {
 }
 
 // Symbol: AXSetMasterVolume
-// Function signature is unknown.
 // PAL: 0x80126608..0x80126620
 MARK_BINARY_BLOB(AXSetMasterVolume, 0x80126608, 0x80126620);
 asm UNKNOWN_FUNCTION(AXSetMasterVolume) {
@@ -806,7 +796,6 @@ lbl_80126618:
 }
 
 // Symbol: AXSetAuxAReturnVolume
-// Function signature is unknown.
 // PAL: 0x80126620..0x80126628
 MARK_BINARY_BLOB(AXSetAuxAReturnVolume, 0x80126620, 0x80126628);
 asm UNKNOWN_FUNCTION(AXSetAuxAReturnVolume) {
@@ -818,7 +807,6 @@ asm UNKNOWN_FUNCTION(AXSetAuxAReturnVolume) {
 }
 
 // Symbol: AXSetAuxBReturnVolume
-// Function signature is unknown.
 // PAL: 0x80126628..0x80126630
 MARK_BINARY_BLOB(AXSetAuxBReturnVolume, 0x80126628, 0x80126630);
 asm UNKNOWN_FUNCTION(AXSetAuxBReturnVolume) {
@@ -830,7 +818,6 @@ asm UNKNOWN_FUNCTION(AXSetAuxBReturnVolume) {
 }
 
 // Symbol: AXSetAuxCReturnVolume
-// Function signature is unknown.
 // PAL: 0x80126630..0x80126638
 MARK_BINARY_BLOB(AXSetAuxCReturnVolume, 0x80126630, 0x80126638);
 asm UNKNOWN_FUNCTION(AXSetAuxCReturnVolume) {

--- a/source/rvl/ax/rvlAxOut.c
+++ b/source/rvl/ax/rvlAxOut.c
@@ -259,7 +259,6 @@ lbl_80126878:
 }
 
 // Symbol: __AXOutAiCallback
-// Function signature is unknown.
 // PAL: 0x80126898..0x80126948
 MARK_BINARY_BLOB(__AXOutAiCallback, 0x80126898, 0x80126948);
 asm UNKNOWN_FUNCTION(__AXOutAiCallback) {
@@ -316,7 +315,6 @@ lbl_80126938:
 }
 
 // Symbol: __AXDSPInitCallback
-// Function signature is unknown.
 // PAL: 0x80126948..0x80126954
 MARK_BINARY_BLOB(__AXDSPInitCallback, 0x80126948, 0x80126954);
 asm UNKNOWN_FUNCTION(__AXDSPInitCallback) {
@@ -329,7 +327,6 @@ asm UNKNOWN_FUNCTION(__AXDSPInitCallback) {
 }
 
 // Symbol: __AXDSPResumeCallback
-// Function signature is unknown.
 // PAL: 0x80126954..0x801269a8
 MARK_BINARY_BLOB(__AXDSPResumeCallback, 0x80126954, 0x801269a8);
 asm UNKNOWN_FUNCTION(__AXDSPResumeCallback) {
@@ -362,7 +359,6 @@ lbl_80126998:
 }
 
 // Symbol: __AXDSPDoneCallback
-// Function signature is unknown.
 // PAL: 0x801269a8..0x801269b8
 MARK_BINARY_BLOB(__AXDSPDoneCallback, 0x801269a8, 0x801269b8);
 asm UNKNOWN_FUNCTION(__AXDSPDoneCallback) {
@@ -376,7 +372,6 @@ asm UNKNOWN_FUNCTION(__AXDSPDoneCallback) {
 }
 
 // Symbol: __AXDSPRequestCallback
-// Function signature is unknown.
 // PAL: 0x801269b8..0x801269bc
 MARK_BINARY_BLOB(__AXDSPRequestCallback, 0x801269b8, 0x801269bc);
 asm UNKNOWN_FUNCTION(__AXDSPRequestCallback) {
@@ -387,7 +382,6 @@ asm UNKNOWN_FUNCTION(__AXDSPRequestCallback) {
 }
 
 // Symbol: __AXOutInitDSP
-// Function signature is unknown.
 // PAL: 0x801269bc..0x80126aac
 MARK_BINARY_BLOB(__AXOutInitDSP, 0x801269bc, 0x80126aac);
 asm UNKNOWN_FUNCTION(__AXOutInitDSP) {
@@ -459,7 +453,6 @@ lbl_80126a84:
 }
 
 // Symbol: __AXOutInit
-// Function signature is unknown.
 // PAL: 0x80126aac..0x80126ca4
 MARK_BINARY_BLOB(__AXOutInit, 0x80126aac, 0x80126ca4);
 asm UNKNOWN_FUNCTION(__AXOutInit) {
@@ -602,7 +595,6 @@ lbl_80126c84:
 }
 
 // Symbol: AXRegisterCallback
-// Function signature is unknown.
 // PAL: 0x80126ca4..0x80126ce8
 MARK_BINARY_BLOB(AXRegisterCallback, 0x80126ca4, 0x80126ce8);
 asm UNKNOWN_FUNCTION(AXRegisterCallback) {
@@ -629,7 +621,6 @@ asm UNKNOWN_FUNCTION(AXRegisterCallback) {
 }
 
 // Symbol: AXRmtGetSamplesLeft
-// Function signature is unknown.
 // PAL: 0x80126ce8..0x80126d14
 MARK_BINARY_BLOB(AXRmtGetSamplesLeft, 0x80126ce8, 0x80126d14);
 asm UNKNOWN_FUNCTION(AXRmtGetSamplesLeft) {
@@ -651,7 +642,6 @@ lbl_80126cfc:
 }
 
 // Symbol: AXRmtGetSamples
-// Function signature is unknown.
 // PAL: 0x80126d14..0x80126dd8
 MARK_BINARY_BLOB(AXRmtGetSamples, 0x80126d14, 0x80126dd8);
 asm UNKNOWN_FUNCTION(AXRmtGetSamples) {
@@ -717,7 +707,6 @@ lbl_80126da4:
 }
 
 // Symbol: AXRmtAdvancePtr
-// Function signature is unknown.
 // PAL: 0x80126dd8..0x80126e30
 MARK_BINARY_BLOB(AXRmtAdvancePtr, 0x80126dd8, 0x80126e30);
 asm UNKNOWN_FUNCTION(AXRmtAdvancePtr) {

--- a/source/rvl/ax/rvlAxSpb.c
+++ b/source/rvl/ax/rvlAxSpb.c
@@ -30,7 +30,6 @@ typedef struct AXSPB {
 AXSPB __AXStudio;
 
 // Symbol: __AXGetStudio
-// Function signature is unknown.
 // PAL: 0x80126e30..0x80126e3c
 MARK_BINARY_BLOB(__AXGetStudio, 0x80126e30, 0x80126e3c);
 asm UNKNOWN_FUNCTION(__AXGetStudio) {
@@ -43,7 +42,6 @@ asm UNKNOWN_FUNCTION(__AXGetStudio) {
 }
 
 // Symbol: __AXDepopFadeMain
-// Function signature is unknown.
 // PAL: 0x80126e3c..0x80126ea8
 MARK_BINARY_BLOB(__AXDepopFadeMain, 0x80126e3c, 0x80126ea8);
 asm UNKNOWN_FUNCTION(__AXDepopFadeMain) {
@@ -83,7 +81,6 @@ lbl_80126e94:
 }
 
 // Symbol: __AXDepopFadeRmt
-// Function signature is unknown.
 // PAL: 0x80126ea8..0x80126f14
 MARK_BINARY_BLOB(__AXDepopFadeRmt, 0x80126ea8, 0x80126f14);
 asm UNKNOWN_FUNCTION(__AXDepopFadeRmt) {
@@ -123,7 +120,6 @@ lbl_80126f00:
 }
 
 // Symbol: __AXPrintStudio
-// Function signature is unknown.
 // PAL: 0x80126f14..0x8012708c
 MARK_BINARY_BLOB(__AXPrintStudio, 0x80126f14, 0x8012708c);
 asm UNKNOWN_FUNCTION(__AXPrintStudio) {
@@ -227,7 +223,6 @@ asm UNKNOWN_FUNCTION(__AXPrintStudio) {
 }
 
 // Symbol: __AXSPBInit
-// Function signature is unknown.
 // PAL: 0x8012708c..0x801270e4
 MARK_BINARY_BLOB(__AXSPBInit, 0x8012708c, 0x801270e4);
 asm UNKNOWN_FUNCTION(__AXSPBInit) {
@@ -259,7 +254,6 @@ asm UNKNOWN_FUNCTION(__AXSPBInit) {
 }
 
 // Symbol: __AXDepopVoice
-// Function signature is unknown.
 // PAL: 0x801270e4..0x80127250
 MARK_BINARY_BLOB(__AXDepopVoice, 0x801270e4, 0x80127250);
 asm UNKNOWN_FUNCTION(__AXDepopVoice) {

--- a/source/rvl/fs/fs.c
+++ b/source/rvl/fs/fs.c
@@ -51,7 +51,6 @@ u32 _unk_80386774;
 u32 _unk_80386770;
 
 // Symbol: ISFS_OpenLib
-// Function signature is unknown.
 // PAL: 0x80169bcc..0x80169cf4
 MARK_BINARY_BLOB(ISFS_OpenLib, 0x80169bcc, 0x80169cf4);
 asm UNKNOWN_FUNCTION(ISFS_OpenLib) {
@@ -141,7 +140,6 @@ lbl_80169cd8:
 }
 
 // Symbol: _isfsFuncCb
-// Function signature is unknown.
 // PAL: 0x80169cf4..0x80169e74
 MARK_BINARY_BLOB(_isfsFuncCb, 0x80169cf4, 0x80169e74);
 asm UNKNOWN_FUNCTION(_isfsFuncCb) {
@@ -256,7 +254,6 @@ lbl_80169e58:
 }
 
 // Symbol: ISFS_CreateDir
-// Function signature is unknown.
 // PAL: 0x80169e74..0x80169f68
 MARK_BINARY_BLOB(ISFS_CreateDir, 0x80169e74, 0x80169f68);
 asm UNKNOWN_FUNCTION(ISFS_CreateDir) {
@@ -332,7 +329,6 @@ lbl_80169f4c:
 }
 
 // Symbol: ISFS_CreateDirAsync
-// Function signature is unknown.
 // PAL: 0x80169f68..0x8016a05c
 MARK_BINARY_BLOB(ISFS_CreateDirAsync, 0x80169f68, 0x8016a05c);
 asm UNKNOWN_FUNCTION(ISFS_CreateDirAsync) {
@@ -407,7 +403,6 @@ lbl_8016a044:
 }
 
 // Symbol: ISFS_ReadDir
-// Function signature is unknown.
 // PAL: 0x8016a05c..0x8016a1b0
 MARK_BINARY_BLOB(ISFS_ReadDir, 0x8016a05c, 0x8016a1b0);
 asm UNKNOWN_FUNCTION(ISFS_ReadDir) {
@@ -509,7 +504,6 @@ lbl_8016a194:
 }
 
 // Symbol: ISFS_ReadDirAsync
-// Function signature is unknown.
 // PAL: 0x8016a1b0..0x8016a2f8
 MARK_BINARY_BLOB(ISFS_ReadDirAsync, 0x8016a1b0, 0x8016a2f8);
 asm UNKNOWN_FUNCTION(ISFS_ReadDirAsync) {
@@ -607,7 +601,6 @@ lbl_8016a2e0:
 }
 
 // Symbol: ISFS_SetAttr
-// Function signature is unknown.
 // PAL: 0x8016a2f8..0x8016a3fc
 MARK_BINARY_BLOB(ISFS_SetAttr, 0x8016a2f8, 0x8016a3fc);
 asm UNKNOWN_FUNCTION(ISFS_SetAttr) {
@@ -687,7 +680,6 @@ lbl_8016a3e0:
 }
 
 // Symbol: ISFS_SetAttrAsync
-// Function signature is unknown.
 // PAL: 0x8016a3fc..0x8016a500
 MARK_BINARY_BLOB(ISFS_SetAttrAsync, 0x8016a3fc, 0x8016a500);
 asm UNKNOWN_FUNCTION(ISFS_SetAttrAsync) {
@@ -766,7 +758,6 @@ lbl_8016a4e8:
 }
 
 // Symbol: ISFS_GetAttr
-// Function signature is unknown.
 // PAL: 0x8016a500..0x8016a658
 MARK_BINARY_BLOB(ISFS_GetAttr, 0x8016a500, 0x8016a658);
 asm UNKNOWN_FUNCTION(ISFS_GetAttr) {
@@ -867,7 +858,6 @@ lbl_8016a63c:
 }
 
 // Symbol: ISFS_GetAttrAsync
-// Function signature is unknown.
 // PAL: 0x8016a658..0x8016a78c
 MARK_BINARY_BLOB(ISFS_GetAttrAsync, 0x8016a658, 0x8016a78c);
 asm UNKNOWN_FUNCTION(ISFS_GetAttrAsync) {
@@ -958,7 +948,6 @@ lbl_8016a774:
 }
 
 // Symbol: ISFS_Delete
-// Function signature is unknown.
 // PAL: 0x8016a78c..0x8016a864
 MARK_BINARY_BLOB(ISFS_Delete, 0x8016a78c, 0x8016a864);
 asm UNKNOWN_FUNCTION(ISFS_Delete) {
@@ -1027,7 +1016,6 @@ lbl_8016a844:
 }
 
 // Symbol: ISFS_DeleteAsync
-// Function signature is unknown.
 // PAL: 0x8016a864..0x8016a934
 MARK_BINARY_BLOB(ISFS_DeleteAsync, 0x8016a864, 0x8016a934);
 asm UNKNOWN_FUNCTION(ISFS_DeleteAsync) {
@@ -1093,7 +1081,6 @@ lbl_8016a91c:
 }
 
 // Symbol: ISFS_Rename
-// Function signature is unknown.
 // PAL: 0x8016a934..0x8016aa38
 MARK_BINARY_BLOB(ISFS_Rename, 0x8016a934, 0x8016aa38);
 asm UNKNOWN_FUNCTION(ISFS_Rename) {
@@ -1173,7 +1160,6 @@ lbl_8016aa1c:
 }
 
 // Symbol: ISFS_RenameAsync
-// Function signature is unknown.
 // PAL: 0x8016aa38..0x8016ab3c
 MARK_BINARY_BLOB(ISFS_RenameAsync, 0x8016aa38, 0x8016ab3c);
 asm UNKNOWN_FUNCTION(ISFS_RenameAsync) {
@@ -1252,7 +1238,6 @@ lbl_8016ab24:
 }
 
 // Symbol: ISFS_GetUsage
-// Function signature is unknown.
 // PAL: 0x8016ab3c..0x8016ac74
 MARK_BINARY_BLOB(ISFS_GetUsage, 0x8016ab3c, 0x8016ac74);
 asm UNKNOWN_FUNCTION(ISFS_GetUsage) {
@@ -1345,7 +1330,6 @@ lbl_8016ac58:
 }
 
 // Symbol: ISFS_CreateFile
-// Function signature is unknown.
 // PAL: 0x8016ac74..0x8016ad68
 MARK_BINARY_BLOB(ISFS_CreateFile, 0x8016ac74, 0x8016ad68);
 asm UNKNOWN_FUNCTION(ISFS_CreateFile) {
@@ -1421,7 +1405,6 @@ lbl_8016ad4c:
 }
 
 // Symbol: ISFS_CreateFileAsync
-// Function signature is unknown.
 // PAL: 0x8016ad68..0x8016ae5c
 MARK_BINARY_BLOB(ISFS_CreateFileAsync, 0x8016ad68, 0x8016ae5c);
 asm UNKNOWN_FUNCTION(ISFS_CreateFileAsync) {
@@ -1496,7 +1479,6 @@ lbl_8016ae44:
 }
 
 // Symbol: ISFS_Open
-// Function signature is unknown.
 // PAL: 0x8016ae5c..0x8016af24
 MARK_BINARY_BLOB(ISFS_Open, 0x8016ae5c, 0x8016af24);
 asm UNKNOWN_FUNCTION(ISFS_Open) {
@@ -1561,7 +1543,6 @@ lbl_8016af00:
 }
 
 // Symbol: ISFS_OpenAsync
-// Function signature is unknown.
 // PAL: 0x8016af24..0x8016afdc
 MARK_BINARY_BLOB(ISFS_OpenAsync, 0x8016af24, 0x8016afdc);
 asm UNKNOWN_FUNCTION(ISFS_OpenAsync) {
@@ -1621,7 +1602,6 @@ lbl_8016afc4:
 }
 
 // Symbol: ISFS_GetFileStats
-// Function signature is unknown.
 // PAL: 0x8016afdc..0x8016b0ac
 MARK_BINARY_BLOB(ISFS_GetFileStats, 0x8016afdc, 0x8016b0ac);
 asm UNKNOWN_FUNCTION(ISFS_GetFileStats) {
@@ -1688,7 +1668,6 @@ lbl_8016b08c:
 }
 
 // Symbol: ISFS_GetFileStatsAsync
-// Function signature is unknown.
 // PAL: 0x8016b0ac..0x8016b16c
 MARK_BINARY_BLOB(ISFS_GetFileStatsAsync, 0x8016b0ac, 0x8016b16c);
 asm UNKNOWN_FUNCTION(ISFS_GetFileStatsAsync) {
@@ -1750,7 +1729,6 @@ lbl_8016b14c:
 }
 
 // Symbol: ISFS_Seek
-// Function signature is unknown.
 // PAL: 0x8016b16c..0x8016b170
 MARK_BINARY_BLOB(ISFS_Seek, 0x8016b16c, 0x8016b170);
 asm UNKNOWN_FUNCTION(ISFS_Seek) {
@@ -1759,7 +1737,6 @@ asm UNKNOWN_FUNCTION(ISFS_Seek) {
 }
 
 // Symbol: ISFS_SeekAsync
-// Function signature is unknown.
 // PAL: 0x8016b170..0x8016b1fc
 MARK_BINARY_BLOB(ISFS_SeekAsync, 0x8016b170, 0x8016b1fc);
 asm UNKNOWN_FUNCTION(ISFS_SeekAsync) {
@@ -1806,7 +1783,6 @@ lbl_8016b1e4:
 }
 
 // Symbol: ISFS_Read
-// Function signature is unknown.
 // PAL: 0x8016b1fc..0x8016b21c
 MARK_BINARY_BLOB(ISFS_Read, 0x8016b1fc, 0x8016b21c);
 asm UNKNOWN_FUNCTION(ISFS_Read) {
@@ -1826,7 +1802,6 @@ lbl_8016b214:
 }
 
 // Symbol: ISFS_ReadAsync
-// Function signature is unknown.
 // PAL: 0x8016b21c..0x8016b2c0
 MARK_BINARY_BLOB(ISFS_ReadAsync, 0x8016b21c, 0x8016b2c0);
 asm UNKNOWN_FUNCTION(ISFS_ReadAsync) {
@@ -1881,7 +1856,6 @@ lbl_8016b2a8:
 }
 
 // Symbol: ISFS_Write
-// Function signature is unknown.
 // PAL: 0x8016b2c0..0x8016b2e0
 MARK_BINARY_BLOB(ISFS_Write, 0x8016b2c0, 0x8016b2e0);
 asm UNKNOWN_FUNCTION(ISFS_Write) {
@@ -1901,7 +1875,6 @@ lbl_8016b2d8:
 }
 
 // Symbol: ISFS_WriteAsync
-// Function signature is unknown.
 // PAL: 0x8016b2e0..0x8016b384
 MARK_BINARY_BLOB(ISFS_WriteAsync, 0x8016b2e0, 0x8016b384);
 asm UNKNOWN_FUNCTION(ISFS_WriteAsync) {
@@ -1956,7 +1929,6 @@ lbl_8016b36c:
 }
 
 // Symbol: ISFS_Close
-// Function signature is unknown.
 // PAL: 0x8016b384..0x8016b388
 MARK_BINARY_BLOB(ISFS_Close, 0x8016b384, 0x8016b388);
 asm UNKNOWN_FUNCTION(ISFS_Close) {
@@ -1967,7 +1939,6 @@ asm UNKNOWN_FUNCTION(ISFS_Close) {
 }
 
 // Symbol: ISFS_CloseAsync
-// Function signature is unknown.
 // PAL: 0x8016b388..0x8016b40c
 MARK_BINARY_BLOB(ISFS_CloseAsync, 0x8016b388, 0x8016b40c);
 asm UNKNOWN_FUNCTION(ISFS_CloseAsync) {
@@ -2012,7 +1983,6 @@ lbl_8016b3f0:
 }
 
 // Symbol: ISFS_ShutdownAsync
-// Function signature is unknown.
 // PAL: 0x8016b40c..0x8016b49c
 MARK_BINARY_BLOB(ISFS_ShutdownAsync, 0x8016b40c, 0x8016b49c);
 asm UNKNOWN_FUNCTION(ISFS_ShutdownAsync) {

--- a/source/rvl/ipc/ipcclt.c
+++ b/source/rvl/ipc/ipcclt.c
@@ -35,7 +35,6 @@ u32 _unk_80386804;
 u32 _unk_80386800;
 
 // Symbol: strnlen
-// Function signature is unknown.
 // PAL: 0x80193048..0x80193074
 MARK_BINARY_BLOB(strnlen, 0x80193048, 0x80193074);
 asm UNKNOWN_FUNCTION(strnlen) {
@@ -59,7 +58,6 @@ lbl_8019306c:
 }
 
 // Symbol: IpcReplyHandler
-// Function signature is unknown.
 // PAL: 0x80193074..0x801932cc
 MARK_BINARY_BLOB(IpcReplyHandler, 0x80193074, 0x801932cc);
 asm UNKNOWN_FUNCTION(IpcReplyHandler) {
@@ -237,7 +235,6 @@ lbl_801932ac:
 }
 
 // Symbol: IPCInterruptHandler
-// Function signature is unknown.
 // PAL: 0x801932cc..0x80193478
 MARK_BINARY_BLOB(IPCInterruptHandler, 0x801932cc, 0x80193478);
 asm UNKNOWN_FUNCTION(IPCInterruptHandler) {
@@ -361,7 +358,6 @@ lbl_80193460:
 }
 
 // Symbol: IPCCltInit
-// Function signature is unknown.
 // PAL: 0x80193478..0x8019352c
 MARK_BINARY_BLOB(IPCCltInit, 0x80193478, 0x8019352c);
 asm UNKNOWN_FUNCTION(IPCCltInit) {
@@ -418,7 +414,6 @@ lbl_8019350c:
 }
 
 // Symbol: IPCCltReInit
-// Function signature is unknown.
 // PAL: 0x8019352c..0x801935a0
 MARK_BINARY_BLOB(IPCCltReInit, 0x8019352c, 0x801935a0);
 asm UNKNOWN_FUNCTION(IPCCltReInit) {
@@ -459,7 +454,6 @@ lbl_80193580:
 }
 
 // Symbol: __ios_Ipc2
-// Function signature is unknown.
 // PAL: 0x801935a0..0x801937e0
 MARK_BINARY_BLOB(__ios_Ipc2, 0x801935a0, 0x801937e0);
 asm UNKNOWN_FUNCTION(__ios_Ipc2) {
@@ -805,7 +799,6 @@ lbl_801939f4:
 }
 
 // Symbol: IOS_CloseAsync
-// Function signature is unknown.
 // PAL: 0x80193a18..0x80193ad8
 MARK_BINARY_BLOB(IOS_CloseAsync, 0x80193a18, 0x80193ad8);
 asm UNKNOWN_FUNCTION(IOS_CloseAsync) {
@@ -922,7 +915,6 @@ lbl_80193b64:
 }
 
 // Symbol: IOS_ReadAsync
-// Function signature is unknown.
 // PAL: 0x80193b80..0x80193c80
 MARK_BINARY_BLOB(IOS_ReadAsync, 0x80193b80, 0x80193c80);
 asm UNKNOWN_FUNCTION(IOS_ReadAsync) {
@@ -1004,7 +996,6 @@ lbl_80193c64:
 }
 
 // Symbol: IOS_Read
-// Function signature is unknown.
 // PAL: 0x80193c80..0x80193d88
 MARK_BINARY_BLOB(IOS_Read, 0x80193c80, 0x80193d88);
 asm UNKNOWN_FUNCTION(IOS_Read) {
@@ -1088,7 +1079,6 @@ lbl_80193d64:
 }
 
 // Symbol: IOS_WriteAsync
-// Function signature is unknown.
 // PAL: 0x80193d88..0x80193e88
 MARK_BINARY_BLOB(IOS_WriteAsync, 0x80193d88, 0x80193e88);
 asm UNKNOWN_FUNCTION(IOS_WriteAsync) {
@@ -1170,7 +1160,6 @@ lbl_80193e6c:
 }
 
 // Symbol: IOS_Write
-// Function signature is unknown.
 // PAL: 0x80193e88..0x80193f90
 MARK_BINARY_BLOB(IOS_Write, 0x80193e88, 0x80193f90);
 asm UNKNOWN_FUNCTION(IOS_Write) {
@@ -1254,7 +1243,6 @@ lbl_80193f6c:
 }
 
 // Symbol: IOS_SeekAsync
-// Function signature is unknown.
 // PAL: 0x80193f90..0x80194070
 MARK_BINARY_BLOB(IOS_SeekAsync, 0x80193f90, 0x80194070);
 asm UNKNOWN_FUNCTION(IOS_SeekAsync) {
@@ -1326,7 +1314,6 @@ lbl_80194054:
 }
 
 // Symbol: IOS_Seek
-// Function signature is unknown.
 // PAL: 0x80194070..0x80194158
 MARK_BINARY_BLOB(IOS_Seek, 0x80194070, 0x80194158);
 asm UNKNOWN_FUNCTION(IOS_Seek) {
@@ -1400,7 +1387,6 @@ lbl_80194134:
 }
 
 // Symbol: IOS_IoctlAsync
-// Function signature is unknown.
 // PAL: 0x80194158..0x80194290
 MARK_BINARY_BLOB(IOS_IoctlAsync, 0x80194158, 0x80194290);
 asm UNKNOWN_FUNCTION(IOS_IoctlAsync) {
@@ -1593,7 +1579,6 @@ lbl_801943a4:
 }
 
 // Symbol: __ios_Ioctlv
-// Function signature is unknown.
 // PAL: 0x801943c0..0x801944fc
 MARK_BINARY_BLOB(__ios_Ioctlv, 0x801943c0, 0x801944fc);
 asm UNKNOWN_FUNCTION(__ios_Ioctlv) {
@@ -1694,7 +1679,6 @@ lbl_801944e0:
 }
 
 // Symbol: IOS_IoctlvAsync
-// Function signature is unknown.
 // PAL: 0x801944fc..0x801945e0
 MARK_BINARY_BLOB(IOS_IoctlvAsync, 0x801944fc, 0x801945e0);
 asm UNKNOWN_FUNCTION(IOS_IoctlvAsync) {
@@ -1765,7 +1749,6 @@ lbl_801945c4:
 }
 
 // Symbol: IOS_Ioctlv
-// Function signature is unknown.
 // PAL: 0x801945e0..0x801946bc
 MARK_BINARY_BLOB(IOS_Ioctlv, 0x801945e0, 0x801946bc);
 asm UNKNOWN_FUNCTION(IOS_Ioctlv) {
@@ -1834,7 +1817,6 @@ lbl_801946a0:
 }
 
 // Symbol: IOS_IoctlvReboot
-// Function signature is unknown.
 // PAL: 0x801946bc..0x801949b8
 MARK_BINARY_BLOB(IOS_IoctlvReboot, 0x801946bc, 0x801949b8);
 asm UNKNOWN_FUNCTION(IOS_IoctlvReboot) {

--- a/source/rvl/kpad/rvlKpad.c
+++ b/source/rvl/kpad/rvlKpad.c
@@ -86,7 +86,6 @@ u32 _unk_8038681c;
 u32 _unk_80386818;
 
 // Symbol: KPADSetFSStickClamp
-// Function signature is unknown.
 // PAL: 0x801950a0..0x801950b4
 MARK_BINARY_BLOB(KPADSetFSStickClamp, 0x801950a0, 0x801950b4);
 asm UNKNOWN_FUNCTION(KPADSetFSStickClamp) {
@@ -101,7 +100,6 @@ asm UNKNOWN_FUNCTION(KPADSetFSStickClamp) {
 }
 
 // Symbol: KPADSetPosParam
-// Function signature is unknown.
 // PAL: 0x801950b4..0x801950d0
 MARK_BINARY_BLOB(KPADSetPosParam, 0x801950b4, 0x801950d0);
 asm UNKNOWN_FUNCTION(KPADSetPosParam) {
@@ -118,7 +116,6 @@ asm UNKNOWN_FUNCTION(KPADSetPosParam) {
 }
 
 // Symbol: KPADSetHoriParam
-// Function signature is unknown.
 // PAL: 0x801950d0..0x80195124
 MARK_BINARY_BLOB(KPADSetHoriParam, 0x801950d0, 0x80195124);
 asm UNKNOWN_FUNCTION(KPADSetHoriParam) {
@@ -149,7 +146,6 @@ asm UNKNOWN_FUNCTION(KPADSetHoriParam) {
 }
 
 // Symbol: reset_kpad
-// Function signature is unknown.
 // PAL: 0x80195124..0x801952f8
 MARK_BINARY_BLOB(reset_kpad, 0x80195124, 0x801952f8);
 asm UNKNOWN_FUNCTION(reset_kpad) {
@@ -278,7 +274,6 @@ lbl_801952c4:
 }
 
 // Symbol: calc_button_repeat
-// Function signature is unknown.
 // PAL: 0x801952f8..0x8019548c
 MARK_BINARY_BLOB(calc_button_repeat, 0x801952f8, 0x8019548c);
 asm UNKNOWN_FUNCTION(calc_button_repeat) {
@@ -396,7 +391,6 @@ lbl_80195444:
 }
 
 // Symbol: calc_acc
-// Function signature is unknown.
 // PAL: 0x8019548c..0x80195540
 MARK_BINARY_BLOB(calc_acc, 0x8019548c, 0x80195540);
 asm UNKNOWN_FUNCTION(calc_acc) {
@@ -457,7 +451,6 @@ lbl_80195520:
 }
 
 // Symbol: calc_acc_horizon
-// Function signature is unknown.
 // PAL: 0x80195540..0x801956d4
 MARK_BINARY_BLOB(calc_acc_horizon, 0x80195540, 0x801956d4);
 asm UNKNOWN_FUNCTION(calc_acc_horizon) {
@@ -572,7 +565,6 @@ lbl_801956b0:
 }
 
 // Symbol: calc_acc_vertical
-// Function signature is unknown.
 // PAL: 0x801956d4..0x801957f8
 MARK_BINARY_BLOB(calc_acc_vertical, 0x801956d4, 0x801957f8);
 asm UNKNOWN_FUNCTION(calc_acc_vertical) {
@@ -658,7 +650,6 @@ lbl_801957cc:
 }
 
 // Symbol: read_kpad_acc
-// Function signature is unknown.
 // PAL: 0x801957f8..0x80195c60
 MARK_BINARY_BLOB(read_kpad_acc, 0x801957f8, 0x80195c60);
 asm UNKNOWN_FUNCTION(read_kpad_acc) {
@@ -973,7 +964,6 @@ lbl_80195c48:
 }
 
 // Symbol: select_2obj_first
-// Function signature is unknown.
 // PAL: 0x80195c60..0x80195e48
 MARK_BINARY_BLOB(select_2obj_first, 0x80195c60, 0x80195e48);
 asm UNKNOWN_FUNCTION(select_2obj_first) {
@@ -1112,7 +1102,6 @@ lbl_80195e08:
 }
 
 // Symbol: select_2obj_continue
-// Function signature is unknown.
 // PAL: 0x80195e48..0x80196070
 MARK_BINARY_BLOB(select_2obj_continue, 0x80195e48, 0x80196070);
 asm UNKNOWN_FUNCTION(select_2obj_continue) {
@@ -1271,7 +1260,6 @@ lbl_80196030:
 }
 
 // Symbol: select_1obj_first
-// Function signature is unknown.
 // PAL: 0x80196070..0x80196224
 MARK_BINARY_BLOB(select_1obj_first, 0x80196070, 0x80196224);
 asm UNKNOWN_FUNCTION(select_1obj_first) {
@@ -1396,7 +1384,6 @@ lbl_8019621c:
 }
 
 // Symbol: select_1obj_continue
-// Function signature is unknown.
 // PAL: 0x80196224..0x80196398
 MARK_BINARY_BLOB(select_1obj_continue, 0x80196224, 0x80196398);
 asm UNKNOWN_FUNCTION(select_1obj_continue) {
@@ -1507,7 +1494,6 @@ lbl_80196390:
 }
 
 // Symbol: calc_dpd_variable
-// Function signature is unknown.
 // PAL: 0x80196398..0x80196964
 MARK_BINARY_BLOB(calc_dpd_variable, 0x80196398, 0x80196964);
 asm UNKNOWN_FUNCTION(calc_dpd_variable) {
@@ -1914,7 +1900,6 @@ lbl_8019694c:
 }
 
 // Symbol: read_kpad_dpd
-// Function signature is unknown.
 // PAL: 0x80196964..0x80196dbc
 MARK_BINARY_BLOB(read_kpad_dpd, 0x80196964, 0x80196dbc);
 asm UNKNOWN_FUNCTION(read_kpad_dpd) {
@@ -2232,7 +2217,6 @@ lbl_80196d88:
 }
 
 // Symbol: clamp_stick_circle
-// Function signature is unknown.
 // PAL: 0x80196dbc..0x80196ee4
 MARK_BINARY_BLOB(clamp_stick_circle, 0x80196dbc, 0x80196ee4);
 asm UNKNOWN_FUNCTION(clamp_stick_circle) {
@@ -2319,7 +2303,6 @@ lbl_80196eb0:
 }
 
 // Symbol: clamp_stick_cross
-// Function signature is unknown.
 // PAL: 0x80196ee4..0x80197108
 MARK_BINARY_BLOB(clamp_stick_cross, 0x80196ee4, 0x80197108);
 asm UNKNOWN_FUNCTION(clamp_stick_cross) {
@@ -2481,7 +2464,6 @@ lbl_801970f4:
 }
 
 // Symbol: read_kpad_stick
-// Function signature is unknown.
 // PAL: 0x80197108..0x80197380
 MARK_BINARY_BLOB(read_kpad_stick, 0x80197108, 0x80197380);
 asm UNKNOWN_FUNCTION(read_kpad_stick) {
@@ -2659,7 +2641,6 @@ lbl_80197364:
 }
 
 // Symbol: KPADRead
-// Function signature is unknown.
 // PAL: 0x80197380..0x80197aac
 MARK_BINARY_BLOB(KPADRead, 0x80197380, 0x80197aac);
 asm UNKNOWN_FUNCTION(KPADRead) {
@@ -3166,7 +3147,6 @@ lbl_80197a94:
 }
 
 // Symbol: KPADInit
-// Function signature is unknown.
 // PAL: 0x80197aac..0x80197da0
 MARK_BINARY_BLOB(KPADInit, 0x80197aac, 0x80197da0);
 asm UNKNOWN_FUNCTION(KPADInit) {
@@ -3375,7 +3355,6 @@ lbl_80197d48:
 }
 
 // Symbol: KPADDisableDPD
-// Function signature is unknown.
 // PAL: 0x80197da0..0x80197dbc
 MARK_BINARY_BLOB(KPADDisableDPD, 0x80197da0, 0x80197dbc);
 asm UNKNOWN_FUNCTION(KPADDisableDPD) {
@@ -3392,7 +3371,6 @@ asm UNKNOWN_FUNCTION(KPADDisableDPD) {
 }
 
 // Symbol: KPADEnableDPD
-// Function signature is unknown.
 // PAL: 0x80197dbc..0x80197dd8
 MARK_BINARY_BLOB(KPADEnableDPD, 0x80197dbc, 0x80197dd8);
 asm UNKNOWN_FUNCTION(KPADEnableDPD) {
@@ -3409,7 +3387,6 @@ asm UNKNOWN_FUNCTION(KPADEnableDPD) {
 }
 
 // Symbol: KPADiSamplingCallback
-// Function signature is unknown.
 // PAL: 0x80197dd8..0x801980b0
 MARK_BINARY_BLOB(KPADiSamplingCallback, 0x80197dd8, 0x801980b0);
 asm UNKNOWN_FUNCTION(KPADiSamplingCallback) {
@@ -3626,7 +3603,6 @@ lbl_80198080:
 }
 
 // Symbol: KPADiControlDpdCallback
-// Function signature is unknown.
 // PAL: 0x801980b0..0x8019812c
 MARK_BINARY_BLOB(KPADiControlDpdCallback, 0x801980b0, 0x8019812c);
 asm UNKNOWN_FUNCTION(KPADiControlDpdCallback) {
@@ -3668,7 +3644,6 @@ lbl_80198110:
 }
 
 // Symbol: KPADGetUnifiedWpadStatus
-// Function signature is unknown.
 // PAL: 0x8019812c..0x801981ec
 MARK_BINARY_BLOB(KPADGetUnifiedWpadStatus, 0x8019812c, 0x801981ec);
 asm UNKNOWN_FUNCTION(KPADGetUnifiedWpadStatus) {

--- a/source/rvl/nand/rvlNand1.c
+++ b/source/rvl/nand/rvlNand1.c
@@ -38,7 +38,6 @@ char _unk_80385a10[] = "/";
 char _unk_80385a14[] = "/%s";
 
 // Symbol: nandCreate
-// Function signature is unknown.
 // PAL: 0x8019b314..0x8019b43c
 MARK_BINARY_BLOB(nandCreate, 0x8019b314, 0x8019b43c);
 asm UNKNOWN_FUNCTION(nandCreate) {
@@ -670,7 +669,6 @@ lbl_8019ba9c:
 }
 
 // Symbol: nandCreateDir
-// Function signature is unknown.
 // PAL: 0x8019bab4..0x8019bbe0
 MARK_BINARY_BLOB(nandCreateDir, 0x8019bab4, 0x8019bbe0);
 asm UNKNOWN_FUNCTION(nandCreateDir) {
@@ -797,7 +795,6 @@ lbl_8019bc38:
 }
 
 // Symbol: NANDPrivateCreateDir
-// Function signature is unknown.
 // PAL: 0x8019bc54..0x8019bcc8
 MARK_BINARY_BLOB(NANDPrivateCreateDir, 0x8019bc54, 0x8019bcc8);
 asm UNKNOWN_FUNCTION(NANDPrivateCreateDir) {
@@ -838,7 +835,6 @@ lbl_8019bcac:
 }
 
 // Symbol: NANDPrivateCreateDirAsync
-// Function signature is unknown.
 // PAL: 0x8019bcc8..0x8019bd40
 MARK_BINARY_BLOB(NANDPrivateCreateDirAsync, 0x8019bcc8, 0x8019bd40);
 asm UNKNOWN_FUNCTION(NANDPrivateCreateDirAsync) {
@@ -880,7 +876,6 @@ lbl_8019bd28:
 }
 
 // Symbol: nandMove
-// Function signature is unknown.
 // PAL: 0x8019bd40..0x8019bee8
 MARK_BINARY_BLOB(nandMove, 0x8019bd40, 0x8019bee8);
 asm UNKNOWN_FUNCTION(nandMove) {
@@ -1080,7 +1075,6 @@ lbl_8019bfb8:
 }
 
 // Symbol: nandGetFileStatusAsyncCallback
-// Function signature is unknown.
 // PAL: 0x8019bfd4..0x8019c048
 MARK_BINARY_BLOB(nandGetFileStatusAsyncCallback, 0x8019bfd4, 0x8019c048);
 asm UNKNOWN_FUNCTION(nandGetFileStatusAsyncCallback) {
@@ -1167,7 +1161,6 @@ lbl_8019c0b8:
 }
 
 // Symbol: nandComposePerm
-// Function signature is unknown.
 // PAL: 0x8019c0d8..0x8019c12c
 MARK_BINARY_BLOB(nandComposePerm, 0x8019c0d8, 0x8019c12c);
 asm UNKNOWN_FUNCTION(nandComposePerm) {
@@ -1204,7 +1197,6 @@ lbl_8019c124:
 }
 
 // Symbol: nandSplitPerm
-// Function signature is unknown.
 // PAL: 0x8019c12c..0x8019c1b8
 MARK_BINARY_BLOB(nandSplitPerm, 0x8019c12c, 0x8019c1b8);
 asm UNKNOWN_FUNCTION(nandSplitPerm) {
@@ -1254,7 +1246,6 @@ lbl_8019c1a0:
 }
 
 // Symbol: nandGetStatus
-// Function signature is unknown.
 // PAL: 0x8019c1b8..0x8019c30c
 MARK_BINARY_BLOB(nandGetStatus, 0x8019c1b8, 0x8019c30c);
 asm UNKNOWN_FUNCTION(nandGetStatus) {
@@ -1353,7 +1344,6 @@ lbl_8019c2ec:
 }
 
 // Symbol: nandGetStatusCallback
-// Function signature is unknown.
 // PAL: 0x8019c30c..0x8019c380
 MARK_BINARY_BLOB(nandGetStatusCallback, 0x8019c30c, 0x8019c380);
 asm UNKNOWN_FUNCTION(nandGetStatusCallback) {
@@ -1427,7 +1417,6 @@ lbl_8019c3cc:
 }
 
 // Symbol: NANDPrivateGetStatus
-// Function signature is unknown.
 // PAL: 0x8019c3e4..0x8019c448
 MARK_BINARY_BLOB(NANDPrivateGetStatus, 0x8019c3e4, 0x8019c448);
 asm UNKNOWN_FUNCTION(NANDPrivateGetStatus) {
@@ -1464,7 +1453,6 @@ lbl_8019c430:
 }
 
 // Symbol: NANDPrivateGetStatusAsync
-// Function signature is unknown.
 // PAL: 0x8019c448..0x8019c4cc
 MARK_BINARY_BLOB(NANDPrivateGetStatusAsync, 0x8019c448, 0x8019c4cc);
 asm UNKNOWN_FUNCTION(NANDPrivateGetStatusAsync) {
@@ -1509,7 +1497,6 @@ lbl_8019c4ac:
 }
 
 // Symbol: nandSetStatus
-// Function signature is unknown.
 // PAL: 0x8019c4cc..0x8019c614
 MARK_BINARY_BLOB(nandSetStatus, 0x8019c4cc, 0x8019c614);
 asm UNKNOWN_FUNCTION(nandSetStatus) {
@@ -1639,7 +1626,6 @@ lbl_8019c660:
 }
 
 // Symbol: NANDPrivateSetStatus
-// Function signature is unknown.
 // PAL: 0x8019c678..0x8019c6dc
 MARK_BINARY_BLOB(NANDPrivateSetStatus, 0x8019c678, 0x8019c6dc);
 asm UNKNOWN_FUNCTION(NANDPrivateSetStatus) {

--- a/source/rvl/nand/rvlNand2.c
+++ b/source/rvl/nand/rvlNand2.c
@@ -24,7 +24,6 @@ char _unk_80385a20[] = "%s/%s";
 u32 _unk_80386840;
 
 // Symbol: nandOpen
-// Function signature is unknown.
 // PAL: 0x8019c6ec..0x8019c800
 MARK_BINARY_BLOB(nandOpen, 0x8019c6ec, 0x8019c800);
 asm UNKNOWN_FUNCTION(nandOpen) {
@@ -155,7 +154,6 @@ lbl_8019c870:
 }
 
 // Symbol: NANDPrivateOpen
-// Function signature is unknown.
 // PAL: 0x8019c88c..0x8019c918
 MARK_BINARY_BLOB(NANDPrivateOpen, 0x8019c88c, 0x8019c918);
 asm UNKNOWN_FUNCTION(NANDPrivateOpen) {
@@ -243,7 +241,6 @@ lbl_8019c978:
 }
 
 // Symbol: NANDPrivateOpenAsync
-// Function signature is unknown.
 // PAL: 0x8019c990..0x8019ca08
 MARK_BINARY_BLOB(NANDPrivateOpenAsync, 0x8019c990, 0x8019ca08);
 asm UNKNOWN_FUNCTION(NANDPrivateOpenAsync) {
@@ -285,7 +282,6 @@ lbl_8019c9f0:
 }
 
 // Symbol: nandOpenCallback
-// Function signature is unknown.
 // PAL: 0x8019ca08..0x8019ca80
 MARK_BINARY_BLOB(nandOpenCallback, 0x8019ca08, 0x8019ca80);
 asm UNKNOWN_FUNCTION(nandOpenCallback) {
@@ -419,7 +415,6 @@ asm s32 NANDSafeOpen(const char*, NANDFileInfo*, u8, void*, u32) {
 }
 
 // Symbol: nandSafeOpen
-// Function signature is unknown.
 // PAL: 0x8019cb80..0x8019cf28
 MARK_BINARY_BLOB(nandSafeOpen, 0x8019cb80, 0x8019cf28);
 asm UNKNOWN_FUNCTION(nandSafeOpen) {
@@ -832,7 +827,6 @@ lbl_8019d0e8:
 }
 
 // Symbol: NANDPrivateSafeOpenAsync
-// Function signature is unknown.
 // PAL: 0x8019d104..0x8019d130
 MARK_BINARY_BLOB(NANDPrivateSafeOpenAsync, 0x8019d104, 0x8019d130);
 asm UNKNOWN_FUNCTION(NANDPrivateSafeOpenAsync) {
@@ -853,7 +847,6 @@ asm UNKNOWN_FUNCTION(NANDPrivateSafeOpenAsync) {
 }
 
 // Symbol: nandSafeOpenAsync
-// Function signature is unknown.
 // PAL: 0x8019d130..0x8019d298
 MARK_BINARY_BLOB(nandSafeOpenAsync, 0x8019d130, 0x8019d298);
 asm UNKNOWN_FUNCTION(nandSafeOpenAsync) {
@@ -962,7 +955,6 @@ lbl_8019d280:
 }
 
 // Symbol: nandSafeOpenCallback
-// Function signature is unknown.
 // PAL: 0x8019d298..0x8019d688
 MARK_BINARY_BLOB(nandSafeOpenCallback, 0x8019d298, 0x8019d688);
 asm UNKNOWN_FUNCTION(nandSafeOpenCallback) {
@@ -1248,7 +1240,6 @@ lbl_8019d670:
 }
 
 // Symbol: nandReadOpenCallback
-// Function signature is unknown.
 // PAL: 0x8019d688..0x8019d720
 MARK_BINARY_BLOB(nandReadOpenCallback, 0x8019d688, 0x8019d720);
 asm UNKNOWN_FUNCTION(nandReadOpenCallback) {
@@ -1381,7 +1372,6 @@ lbl_8019d804:
 }
 
 // Symbol: nandSafeCloseCallback
-// Function signature is unknown.
 // PAL: 0x8019d824..0x8019d9e8
 MARK_BINARY_BLOB(nandSafeCloseCallback, 0x8019d824, 0x8019d9e8);
 asm UNKNOWN_FUNCTION(nandSafeCloseCallback) {
@@ -1514,7 +1504,6 @@ lbl_8019d9d4:
 }
 
 // Symbol: nandReadCloseCallback
-// Function signature is unknown.
 // PAL: 0x8019d9e8..0x8019da44
 MARK_BINARY_BLOB(nandReadCloseCallback, 0x8019d9e8, 0x8019da44);
 asm UNKNOWN_FUNCTION(nandReadCloseCallback) {
@@ -1548,7 +1537,6 @@ lbl_8019da1c:
 }
 
 // Symbol: nandCloseCallback
-// Function signature is unknown.
 // PAL: 0x8019da44..0x8019daa0
 MARK_BINARY_BLOB(nandCloseCallback, 0x8019da44, 0x8019daa0);
 asm UNKNOWN_FUNCTION(nandCloseCallback) {

--- a/source/rvl/nand/rvlNand3.c
+++ b/source/rvl/nand/rvlNand3.c
@@ -91,7 +91,6 @@ u32 _unk_80386850;
 u64 _unk_80386848;
 
 // Symbol: nandRemoveTailToken
-// Function signature is unknown.
 // PAL: 0x8019daa0..0x8019db74
 MARK_BINARY_BLOB(nandRemoveTailToken, 0x8019daa0, 0x8019db74);
 asm UNKNOWN_FUNCTION(nandRemoveTailToken) {
@@ -159,7 +158,6 @@ lbl_8019db58:
 }
 
 // Symbol: nandGetHeadToken
-// Function signature is unknown.
 // PAL: 0x8019db74..0x8019dc48
 MARK_BINARY_BLOB(nandGetHeadToken, 0x8019db74, 0x8019dc48);
 asm UNKNOWN_FUNCTION(nandGetHeadToken) {
@@ -228,7 +226,6 @@ lbl_8019dc30:
 }
 
 // Symbol: nandGetRelativeName
-// Function signature is unknown.
 // PAL: 0x8019dc48..0x8019dce0
 MARK_BINARY_BLOB(nandGetRelativeName, 0x8019dc48, 0x8019dce0);
 asm UNKNOWN_FUNCTION(nandGetRelativeName) {
@@ -280,7 +277,6 @@ lbl_8019dcc8:
 }
 
 // Symbol: nandConvertPath
-// Function signature is unknown.
 // PAL: 0x8019dce0..0x8019de1c
 MARK_BINARY_BLOB(nandConvertPath, 0x8019dce0, 0x8019de1c);
 asm UNKNOWN_FUNCTION(nandConvertPath) {
@@ -377,7 +373,6 @@ lbl_8019de00:
 }
 
 // Symbol: nandIsPrivatePath
-// Function signature is unknown.
 // PAL: 0x8019de1c..0x8019de50
 MARK_BINARY_BLOB(nandIsPrivatePath, 0x8019de1c, 0x8019de50);
 asm UNKNOWN_FUNCTION(nandIsPrivatePath) {
@@ -400,7 +395,6 @@ asm UNKNOWN_FUNCTION(nandIsPrivatePath) {
 }
 
 // Symbol: nandIsUnderPrivatePath
-// Function signature is unknown.
 // PAL: 0x8019de50..0x8019dea8
 MARK_BINARY_BLOB(nandIsUnderPrivatePath, 0x8019de50, 0x8019dea8);
 asm UNKNOWN_FUNCTION(nandIsUnderPrivatePath) {
@@ -434,7 +428,6 @@ lbl_8019de94:
 }
 
 // Symbol: nandIsInitialized
-// Function signature is unknown.
 // PAL: 0x8019dea8..0x8019debc
 MARK_BINARY_BLOB(nandIsInitialized, 0x8019dea8, 0x8019debc);
 asm UNKNOWN_FUNCTION(nandIsInitialized) {
@@ -449,7 +442,6 @@ asm UNKNOWN_FUNCTION(nandIsInitialized) {
 }
 
 // Symbol: nandReportErrorCode
-// Function signature is unknown.
 // PAL: 0x8019debc..0x8019dec0
 MARK_BINARY_BLOB(nandReportErrorCode, 0x8019debc, 0x8019dec0);
 asm UNKNOWN_FUNCTION(nandReportErrorCode) {
@@ -460,7 +452,6 @@ asm UNKNOWN_FUNCTION(nandReportErrorCode) {
 }
 
 // Symbol: nandConvertErrorCode
-// Function signature is unknown.
 // PAL: 0x8019dec0..0x8019e020
 MARK_BINARY_BLOB(nandConvertErrorCode, 0x8019dec0, 0x8019e020);
 asm UNKNOWN_FUNCTION(nandConvertErrorCode) {
@@ -565,7 +556,6 @@ lbl_8019e000:
 }
 
 // Symbol: nandGenerateAbsPath
-// Function signature is unknown.
 // PAL: 0x8019e020..0x8019e0e8
 MARK_BINARY_BLOB(nandGenerateAbsPath, 0x8019e020, 0x8019e0e8);
 asm UNKNOWN_FUNCTION(nandGenerateAbsPath) {
@@ -630,7 +620,6 @@ lbl_8019e0d0:
 }
 
 // Symbol: nandGetParentDirectory
-// Function signature is unknown.
 // PAL: 0x8019e0e8..0x8019e18c
 MARK_BINARY_BLOB(nandGetParentDirectory, 0x8019e0e8, 0x8019e18c);
 asm UNKNOWN_FUNCTION(nandGetParentDirectory) {
@@ -775,7 +764,6 @@ lbl_8019e2a0:
 }
 
 // Symbol: nandOnShutdown
-// Function signature is unknown.
 // PAL: 0x8019e2b8..0x8019e390
 MARK_BINARY_BLOB(nandOnShutdown, 0x8019e2b8, 0x8019e390);
 asm UNKNOWN_FUNCTION(nandOnShutdown) {
@@ -919,7 +907,6 @@ lbl_8019e450:
 }
 
 // Symbol: nandCallback
-// Function signature is unknown.
 // PAL: 0x8019e460..0x8019e49c
 MARK_BINARY_BLOB(nandCallback, 0x8019e460, 0x8019e49c);
 asm UNKNOWN_FUNCTION(nandCallback) {
@@ -944,7 +931,6 @@ asm UNKNOWN_FUNCTION(nandCallback) {
 }
 
 // Symbol: nandGetType
-// Function signature is unknown.
 // PAL: 0x8019e49c..0x8019e770
 MARK_BINARY_BLOB(nandGetType, 0x8019e49c, 0x8019e770);
 asm UNKNOWN_FUNCTION(nandGetType) {
@@ -1182,7 +1168,6 @@ lbl_8019e7a4:
 }
 
 // Symbol: NANDPrivateGetTypeAsync
-// Function signature is unknown.
 // PAL: 0x8019e7b4..0x8019e7fc
 MARK_BINARY_BLOB(NANDPrivateGetTypeAsync, 0x8019e7b4, 0x8019e7fc);
 asm UNKNOWN_FUNCTION(NANDPrivateGetTypeAsync) {
@@ -1212,7 +1197,6 @@ lbl_8019e7ec:
 }
 
 // Symbol: nandGetTypeCallback
-// Function signature is unknown.
 // PAL: 0x8019e7fc..0x8019e874
 MARK_BINARY_BLOB(nandGetTypeCallback, 0x8019e7fc, 0x8019e874);
 asm UNKNOWN_FUNCTION(nandGetTypeCallback) {
@@ -1325,7 +1309,6 @@ lbl_8019e93c:
 }
 
 // Symbol: NANDSecretGetUsage
-// Function signature is unknown.
 // PAL: 0x8019e95c..0x8019ea14
 MARK_BINARY_BLOB(NANDSecretGetUsage, 0x8019e95c, 0x8019ea14);
 asm UNKNOWN_FUNCTION(NANDSecretGetUsage) {
@@ -1383,7 +1366,6 @@ lbl_8019e9f8:
 }
 
 // Symbol: nandCalcUsage
-// Function signature is unknown.
 // PAL: 0x8019ea14..0x8019ead0
 MARK_BINARY_BLOB(nandCalcUsage, 0x8019ea14, 0x8019ead0);
 asm UNKNOWN_FUNCTION(nandCalcUsage) {
@@ -1526,7 +1508,6 @@ lbl_8019ebbc:
 }
 
 // Symbol: reserveFileDescriptor
-// Function signature is unknown.
 // PAL: 0x8019ebd8..0x8019ec2c
 MARK_BINARY_BLOB(reserveFileDescriptor, 0x8019ebd8, 0x8019ec2c);
 asm UNKNOWN_FUNCTION(reserveFileDescriptor) {
@@ -1559,7 +1540,6 @@ lbl_8019ec0c:
 }
 
 // Symbol: NANDLoggingAddMessageAsync
-// Function signature is unknown.
 // PAL: 0x8019ec2c..0x8019ed24
 MARK_BINARY_BLOB(NANDLoggingAddMessageAsync, 0x8019ec2c, 0x8019ed24);
 asm UNKNOWN_FUNCTION(NANDLoggingAddMessageAsync) {
@@ -1635,7 +1615,6 @@ lbl_8019ed0c:
 }
 
 // Symbol: asyncRoutine
-// Function signature is unknown.
 // PAL: 0x8019ed24..0x8019f1a8
 MARK_BINARY_BLOB(asyncRoutine, 0x8019ed24, 0x8019f1a8);
 asm UNKNOWN_FUNCTION(asyncRoutine) {

--- a/source/rvl/os/osAudio.c
+++ b/source/rvl/os/osAudio.c
@@ -7,7 +7,6 @@
 #include "osCache.h"
 
 // Symbol: __AIClockInit
-// Function signature is unknown.
 // PAL: 0x801a1138..0x801a1358
 MARK_BINARY_BLOB(__AIClockInit, 0x801a1138, 0x801a1358);
 asm UNKNOWN_FUNCTION(__AIClockInit) {
@@ -160,7 +159,6 @@ lbl_801a1310:
 }
 
 // Symbol: __OSInitAudioSystem
-// Function signature is unknown.
 // PAL: 0x801a1358..0x801a1520
 MARK_BINARY_BLOB(__OSInitAudioSystem, 0x801a1358, 0x801a1520);
 asm UNKNOWN_FUNCTION(__OSInitAudioSystem) {
@@ -296,7 +294,6 @@ lbl_801a14e8:
 }
 
 // Symbol: __OSStopAudioSystem
-// Function signature is unknown.
 // PAL: 0x801a1520..0x801a15ec
 MARK_BINARY_BLOB(__OSStopAudioSystem, 0x801a1520, 0x801a15ec);
 asm UNKNOWN_FUNCTION(__OSStopAudioSystem) {

--- a/source/rvl/os/osCache.c
+++ b/source/rvl/os/osCache.c
@@ -329,7 +329,6 @@ _again:
 }
 
 // Symbol: DMAErrorHandler
-// Function signature is unknown.
 // PAL: 0x801a199c..0x801a1ae4
 MARK_BINARY_BLOB(DMAErrorHandler, 0x801a199c, 0x801a1ae4);
 asm UNKNOWN_FUNCTION(DMAErrorHandler) {
@@ -428,7 +427,6 @@ lbl_801a1ac0:
 }
 
 // Symbol: __OSCacheInit
-// Function signature is unknown.
 // PAL: 0x801a1ae4..0x801a1c1c
 MARK_BINARY_BLOB(__OSCacheInit, 0x801a1ae4, 0x801a1c1c);
 asm UNKNOWN_FUNCTION(__OSCacheInit) {

--- a/source/rvl/os/osContext.c
+++ b/source/rvl/os/osContext.c
@@ -12,7 +12,6 @@ volatile OSContext* __OSCurrentContext : 0x800000d4;
 volatile OSContext* __OSFPUContext : 0x800000d8;
 
 // Symbol: __OSLoadFPUContext
-// Function signature is unknown.
 // PAL: 0x801a1c1c..0x801a1d40
 MARK_BINARY_BLOB(__OSLoadFPUContext, 0x801a1c1c, 0x801a1d40);
 asm UNKNOWN_FUNCTION(__OSLoadFPUContext) {
@@ -97,7 +96,6 @@ lbl_801a1d3c:
 }
 
 // Symbol: __OSSaveFPUContext
-// Function signature is unknown.
 // PAL: 0x801a1d40..0x801a1e68
 MARK_BINARY_BLOB(__OSSaveFPUContext, 0x801a1d40, 0x801a1e68);
 asm UNKNOWN_FUNCTION(__OSSaveFPUContext) {
@@ -227,7 +225,6 @@ lbl_801a1ea8:
 OSContext* OSGetCurrentContext(void) { return (OSContext*)__OSCurrentContext; }
 
 // Symbol: OSSaveContext
-// Function signature is unknown.
 // PAL: 0x801a1ed8..0x801a1f58
 MARK_BINARY_BLOB(OSSaveContext, 0x801a1ed8, 0x801a1f58);
 asm UNKNOWN_FUNCTION(OSSaveContext) {
@@ -269,7 +266,6 @@ asm UNKNOWN_FUNCTION(OSSaveContext) {
 }
 
 // Symbol: OSLoadContext
-// Function signature is unknown.
 // PAL: 0x801a1f58..0x801a2030
 MARK_BINARY_BLOB(OSLoadContext, 0x801a1f58, 0x801a2030);
 asm void OSLoadContext(OSContext* context) {
@@ -344,7 +340,6 @@ asm u32 OSGetStackPointer(void) {
 }
 
 // Symbol: OSSwitchFiber
-// Function signature is unknown.
 // PAL: 0x801a2038..0x801a2068
 MARK_BINARY_BLOB(OSSwitchFiber, 0x801a2038, 0x801a2068);
 asm UNKNOWN_FUNCTION(OSSwitchFiber) {
@@ -366,7 +361,6 @@ asm UNKNOWN_FUNCTION(OSSwitchFiber) {
 }
 
 // Symbol: OSSwitchFiberEx
-// Function signature is unknown.
 // PAL: 0x801a2068..0x801a2098
 MARK_BINARY_BLOB(OSSwitchFiberEx, 0x801a2068, 0x801a2098);
 asm UNKNOWN_FUNCTION(OSSwitchFiberEx) {
@@ -498,7 +492,6 @@ void OSDumpContext(OSContext* context) {
 }
 
 // Symbol: OSSwitchFPUContext
-// Function signature is unknown.
 // PAL: 0x801a23d8..0x801a245c
 MARK_BINARY_BLOB(OSSwitchFPUContext, 0x801a23d8, 0x801a245c);
 asm UNKNOWN_FUNCTION(OSSwitchFPUContext) {
@@ -543,7 +536,6 @@ lbl_801a2418:
 }
 
 // Symbol: __OSContextInit
-// Function signature is unknown.
 // PAL: 0x801a245c..0x801a24a4
 MARK_BINARY_BLOB(__OSContextInit, 0x801a245c, 0x801a24a4);
 asm UNKNOWN_FUNCTION(__OSContextInit) {
@@ -571,7 +563,6 @@ asm UNKNOWN_FUNCTION(__OSContextInit) {
 }
 
 // Symbol: OSFillFPUContext
-// Function signature is unknown.
 // PAL: 0x801a24a4..0x801a25d0
 MARK_BINARY_BLOB(OSFillFPUContext, 0x801a24a4, 0x801a25d0);
 asm UNKNOWN_FUNCTION(OSFillFPUContext) {

--- a/source/rvl/os/osFatal.c
+++ b/source/rvl/os/osFatal.c
@@ -70,7 +70,6 @@ asm void float_ordering() {
 }
 
 // Symbol: ScreenReport
-// Function signature is unknown.
 // PAL: 0x801a4aa4..0x801a4dc8
 MARK_BINARY_BLOB(ScreenReport, 0x801a4aa4, 0x801a4dc8);
 asm UNKNOWN_FUNCTION(ScreenReport) {
@@ -292,7 +291,6 @@ lbl_801a4db0:
 }
 
 // Symbol: ConfigureVideo
-// Function signature is unknown.
 // PAL: 0x801a4dc8..0x801a4ec4
 MARK_BINARY_BLOB(ConfigureVideo, 0x801a4dc8, 0x801a4ec4);
 asm UNKNOWN_FUNCTION(ConfigureVideo) {
@@ -371,7 +369,6 @@ lbl_801a4e98:
 }
 
 // Symbol: OSFatal
-// Function signature is unknown.
 // PAL: 0x801a4ec4..0x801a50dc
 MARK_BINARY_BLOB(OSFatal, 0x801a4ec4, 0x801a50dc);
 asm UNKNOWN_FUNCTION(OSFatal) {
@@ -523,7 +520,6 @@ lbl_801a5068:
 }
 
 // Symbol: Halt
-// Function signature is unknown.
 // PAL: 0x801a50dc..0x801a56dc
 MARK_BINARY_BLOB(Halt, 0x801a50dc, 0x801a56dc);
 asm UNKNOWN_FUNCTION(Halt) {

--- a/source/rvl/os/osFont.c
+++ b/source/rvl/os/osFont.c
@@ -13,7 +13,6 @@ extern UNKNOWN_FUNCTION(OSUTF32toANSI);
 extern UNKNOWN_FUNCTION(OSUTF32toSJIS);
 
 // Symbol: GetFontCode
-// Function signature is unknown.
 // PAL: 0x801a56dc..0x801a5810
 MARK_BINARY_BLOB(GetFontCode, 0x801a56dc, 0x801a5810);
 asm UNKNOWN_FUNCTION(GetFontCode) {
@@ -110,7 +109,6 @@ lbl_801a5808:
 }
 
 // Symbol: Decode
-// Function signature is unknown.
 // PAL: 0x801a5810..0x801a59b4
 MARK_BINARY_BLOB(Decode, 0x801a5810, 0x801a59b4);
 asm UNKNOWN_FUNCTION(Decode) {
@@ -235,7 +233,6 @@ lbl_801a598c:
 }
 
 // Symbol: OSSetFontEncode
-// Function signature is unknown.
 // PAL: 0x801a59b4..0x801a5a34
 MARK_BINARY_BLOB(OSSetFontEncode, 0x801a59b4, 0x801a5a34);
 asm UNKNOWN_FUNCTION(OSSetFontEncode) {
@@ -283,7 +280,6 @@ lbl_801a5a2c:
 }
 
 // Symbol: ReadFont
-// Function signature is unknown.
 // PAL: 0x801a5a34..0x801a5d34
 MARK_BINARY_BLOB(ReadFont, 0x801a5a34, 0x801a5d34);
 asm UNKNOWN_FUNCTION(ReadFont) {
@@ -500,7 +496,6 @@ lbl_801a5d1c:
 }
 
 // Symbol: OSLoadFont
-// Function signature is unknown.
 // PAL: 0x801a5d34..0x801a5e5c
 MARK_BINARY_BLOB(OSLoadFont, 0x801a5d34, 0x801a5e5c);
 asm UNKNOWN_FUNCTION(OSLoadFont) {
@@ -595,7 +590,6 @@ lbl_801a5e40:
 }
 
 // Symbol: ParseStringS
-// Function signature is unknown.
 // PAL: 0x801a5e5c..0x801a5f58
 MARK_BINARY_BLOB(ParseStringS, 0x801a5e5c, 0x801a5f58);
 asm UNKNOWN_FUNCTION(ParseStringS) {
@@ -675,7 +669,6 @@ lbl_801a5f2c:
 }
 
 // Symbol: ParseStringW
-// Function signature is unknown.
 // PAL: 0x801a5f58..0x801a6114
 MARK_BINARY_BLOB(ParseStringW, 0x801a5f58, 0x801a6114);
 asm UNKNOWN_FUNCTION(ParseStringW) {
@@ -809,7 +802,6 @@ lbl_801a60e4:
 }
 
 // Symbol: OSGetFontTexel
-// Function signature is unknown.
 // PAL: 0x801a6114..0x801a63a4
 MARK_BINARY_BLOB(OSGetFontTexel, 0x801a6114, 0x801a63a4);
 asm UNKNOWN_FUNCTION(OSGetFontTexel) {

--- a/source/rvl/os/osMemory.c
+++ b/source/rvl/os/osMemory.c
@@ -25,7 +25,6 @@ extern UNKNOWN_FUNCTION(__OSUnmaskInterrupts);
 extern UNKNOWN_FUNCTION(OSRegisterShutdownFunction);
 
 // Symbol: OSGetPhysicalMem1Size
-// Function signature is unknown.
 // PAL: 0x801a75d0..0x801a75dc
 MARK_BINARY_BLOB(OSGetPhysicalMem1Size, 0x801a75d0, 0x801a75dc);
 asm UNKNOWN_FUNCTION(OSGetPhysicalMem1Size) {
@@ -38,7 +37,6 @@ asm UNKNOWN_FUNCTION(OSGetPhysicalMem1Size) {
 }
 
 // Symbol: OSGetPhysicalMem2Size
-// Function signature is unknown.
 // PAL: 0x801a75dc..0x801a75e8
 MARK_BINARY_BLOB(OSGetPhysicalMem2Size, 0x801a75dc, 0x801a75e8);
 asm UNKNOWN_FUNCTION(OSGetPhysicalMem2Size) {
@@ -51,7 +49,6 @@ asm UNKNOWN_FUNCTION(OSGetPhysicalMem2Size) {
 }
 
 // Symbol: OSGetConsoleSimulatedMem1Size
-// Function signature is unknown.
 // PAL: 0x801a75e8..0x801a75f4
 MARK_BINARY_BLOB(OSGetConsoleSimulatedMem1Size, 0x801a75e8, 0x801a75f4);
 asm UNKNOWN_FUNCTION(OSGetConsoleSimulatedMem1Size) {
@@ -64,7 +61,6 @@ asm UNKNOWN_FUNCTION(OSGetConsoleSimulatedMem1Size) {
 }
 
 // Symbol: OSGetConsoleSimulatedMem2Size
-// Function signature is unknown.
 // PAL: 0x801a75f4..0x801a7600
 MARK_BINARY_BLOB(OSGetConsoleSimulatedMem2Size, 0x801a75f4, 0x801a7600);
 asm UNKNOWN_FUNCTION(OSGetConsoleSimulatedMem2Size) {
@@ -77,7 +73,6 @@ asm UNKNOWN_FUNCTION(OSGetConsoleSimulatedMem2Size) {
 }
 
 // Symbol: OnShutdown
-// Function signature is unknown.
 // PAL: 0x801a7600..0x801a763c
 MARK_BINARY_BLOB(OnShutdown, 0x801a7600, 0x801a763c);
 asm UNKNOWN_FUNCTION(OnShutdown) {
@@ -103,7 +98,6 @@ lbl_801a7628:
 }
 
 // Symbol: MEMIntrruptHandler
-// Function signature is unknown.
 // PAL: 0x801a763c..0x801a7684
 MARK_BINARY_BLOB(MEMIntrruptHandler, 0x801a763c, 0x801a7684);
 asm UNKNOWN_FUNCTION(MEMIntrruptHandler) {
@@ -132,7 +126,6 @@ lbl_801a767c:
 }
 
 // Symbol: OSProtectRange
-// Function signature is unknown.
 // PAL: 0x801a7684..0x801a774c
 MARK_BINARY_BLOB(OSProtectRange, 0x801a7684, 0x801a774c);
 asm UNKNOWN_FUNCTION(OSProtectRange) {
@@ -194,7 +187,6 @@ lbl_801a7734:
 }
 
 // Symbol: ConfigMEM1_24MB
-// Function signature is unknown.
 // PAL: 0x801a774c..0x801a77cc
 MARK_BINARY_BLOB(ConfigMEM1_24MB, 0x801a774c, 0x801a77cc);
 asm UNKNOWN_FUNCTION(ConfigMEM1_24MB) {
@@ -236,7 +228,6 @@ asm UNKNOWN_FUNCTION(ConfigMEM1_24MB) {
 }
 
 // Symbol: ConfigMEM1_48MB
-// Function signature is unknown.
 // PAL: 0x801a77cc..0x801a784c
 MARK_BINARY_BLOB(ConfigMEM1_48MB, 0x801a77cc, 0x801a784c);
 asm UNKNOWN_FUNCTION(ConfigMEM1_48MB) {
@@ -278,7 +269,6 @@ asm UNKNOWN_FUNCTION(ConfigMEM1_48MB) {
 }
 
 // Symbol: ConfigMEM2_52MB
-// Function signature is unknown.
 // PAL: 0x801a784c..0x801a792c
 MARK_BINARY_BLOB(ConfigMEM2_52MB, 0x801a784c, 0x801a792c);
 asm UNKNOWN_FUNCTION(ConfigMEM2_52MB) {
@@ -344,7 +334,6 @@ asm UNKNOWN_FUNCTION(ConfigMEM2_52MB) {
 }
 
 // Symbol: ConfigMEM2_56MB
-// Function signature is unknown.
 // PAL: 0x801a792c..0x801a7a0c
 MARK_BINARY_BLOB(ConfigMEM2_56MB, 0x801a792c, 0x801a7a0c);
 asm UNKNOWN_FUNCTION(ConfigMEM2_56MB) {
@@ -410,7 +399,6 @@ asm UNKNOWN_FUNCTION(ConfigMEM2_56MB) {
 }
 
 // Symbol: ConfigMEM2_64MB
-// Function signature is unknown.
 // PAL: 0x801a7a0c..0x801a7ab8
 MARK_BINARY_BLOB(ConfigMEM2_64MB, 0x801a7a0c, 0x801a7ab8);
 asm UNKNOWN_FUNCTION(ConfigMEM2_64MB) {
@@ -463,7 +451,6 @@ asm UNKNOWN_FUNCTION(ConfigMEM2_64MB) {
 }
 
 // Symbol: ConfigMEM2_112MB
-// Function signature is unknown.
 // PAL: 0x801a7ab8..0x801a7b98
 MARK_BINARY_BLOB(ConfigMEM2_112MB, 0x801a7ab8, 0x801a7b98);
 asm UNKNOWN_FUNCTION(ConfigMEM2_112MB) {
@@ -529,7 +516,6 @@ asm UNKNOWN_FUNCTION(ConfigMEM2_112MB) {
 }
 
 // Symbol: ConfigMEM2_128MB
-// Function signature is unknown.
 // PAL: 0x801a7b98..0x801a7c44
 MARK_BINARY_BLOB(ConfigMEM2_128MB, 0x801a7b98, 0x801a7c44);
 asm UNKNOWN_FUNCTION(ConfigMEM2_128MB) {
@@ -582,7 +568,6 @@ asm UNKNOWN_FUNCTION(ConfigMEM2_128MB) {
 }
 
 // Symbol: ConfigMEM_ES1_0
-// Function signature is unknown.
 // PAL: 0x801a7c44..0x801a7c94
 MARK_BINARY_BLOB(ConfigMEM_ES1_0, 0x801a7c44, 0x801a7c94);
 asm UNKNOWN_FUNCTION(ConfigMEM_ES1_0) {
@@ -612,7 +597,6 @@ asm UNKNOWN_FUNCTION(ConfigMEM_ES1_0) {
 }
 
 // Symbol: RealMode
-// Function signature is unknown.
 // PAL: 0x801a7c94..0x801a7cac
 MARK_BINARY_BLOB(RealMode, 0x801a7c94, 0x801a7cac);
 asm UNKNOWN_FUNCTION(RealMode) {
@@ -628,7 +612,6 @@ asm UNKNOWN_FUNCTION(RealMode) {
 }
 
 // Symbol: BATConfig
-// Function signature is unknown.
 // PAL: 0x801a7cac..0x801a7dfc
 MARK_BINARY_BLOB(BATConfig, 0x801a7cac, 0x801a7dfc);
 asm UNKNOWN_FUNCTION(BATConfig) {
@@ -731,7 +714,6 @@ lbl_801a7de8:
 }
 
 // Symbol: __OSInitMemoryProtection
-// Function signature is unknown.
 // PAL: 0x801a7dfc..0x801a7eac
 MARK_BINARY_BLOB(__OSInitMemoryProtection, 0x801a7dfc, 0x801a7eac);
 asm UNKNOWN_FUNCTION(__OSInitMemoryProtection) {

--- a/source/rvl/os/osMessage.c
+++ b/source/rvl/os/osMessage.c
@@ -170,7 +170,6 @@ lbl_801a74e0:
 }
 
 // Symbol: OSJamMessage
-// Function signature is unknown.
 // PAL: 0x801a7500..0x801a75d0
 MARK_BINARY_BLOB(OSJamMessage, 0x801a7500, 0x801a75d0);
 asm UNKNOWN_FUNCTION(OSJamMessage) {

--- a/source/rvl/os/osMutex.c
+++ b/source/rvl/os/osMutex.c
@@ -162,7 +162,6 @@ lbl_801a8064:
 }
 
 // Symbol: __OSUnlockAllMutex
-// Function signature is unknown.
 // PAL: 0x801a8088..0x801a80f4
 MARK_BINARY_BLOB(__OSUnlockAllMutex, 0x801a8088, 0x801a80f4);
 asm UNKNOWN_FUNCTION(__OSUnlockAllMutex) {
@@ -264,7 +263,6 @@ lbl_801a8188:
 }
 
 // Symbol: OSInitCond
-// Function signature is unknown.
 // PAL: 0x801a81b0..0x801a81b4
 MARK_BINARY_BLOB(OSInitCond, 0x801a81b0, 0x801a81b4);
 asm UNKNOWN_FUNCTION(OSInitCond) {
@@ -275,7 +273,6 @@ asm UNKNOWN_FUNCTION(OSInitCond) {
 }
 
 // Symbol: OSSignalCond
-// Function signature is unknown.
 // PAL: 0x801a81b4..0x801a81b8
 MARK_BINARY_BLOB(OSSignalCond, 0x801a81b4, 0x801a81b8);
 asm UNKNOWN_FUNCTION(OSSignalCond) {

--- a/source/rvl/os/osReboot.c
+++ b/source/rvl/os/osReboot.c
@@ -11,7 +11,6 @@ u32 _unk_80386904;
 u32 _unk_80386900;
 
 // Symbol: __OSReboot
-// Function signature is unknown.
 // PAL: 0x801a81b8..0x801a8224
 MARK_BINARY_BLOB(__OSReboot, 0x801a81b8, 0x801a8224);
 asm UNKNOWN_FUNCTION(__OSReboot) {
@@ -48,7 +47,6 @@ asm UNKNOWN_FUNCTION(__OSReboot) {
 }
 
 // Symbol: OSGetSaveRegion
-// Function signature is unknown.
 // PAL: 0x801a8224..0x801a8238
 MARK_BINARY_BLOB(OSGetSaveRegion, 0x801a8224, 0x801a8238);
 asm UNKNOWN_FUNCTION(OSGetSaveRegion) {

--- a/source/rvl/os/osReset.c
+++ b/source/rvl/os/osReset.c
@@ -64,7 +64,6 @@ extern UNKNOWN_FUNCTION(SCGetIdleMode);
 extern UNKNOWN_FUNCTION(__VISetRGBModeImm);
 
 // Symbol: OSRegisterShutdownFunction
-// Function signature is unknown.
 // PAL: 0x801a8238..0x801a82c0
 MARK_BINARY_BLOB(OSRegisterShutdownFunction, 0x801a8238, 0x801a82c0);
 asm void OSRegisterShutdownFunction(OSShutdownFunctionInfo* info) {
@@ -115,7 +114,6 @@ lbl_801a82b8:
 }
 
 // Symbol: __OSCallShutdownFunctions
-// Function signature is unknown.
 // PAL: 0x801a82c0..0x801a8370
 MARK_BINARY_BLOB(__OSCallShutdownFunctions, 0x801a82c0, 0x801a8370);
 asm UNKNOWN_FUNCTION(__OSCallShutdownFunctions) {
@@ -173,7 +171,6 @@ lbl_801a8338:
 }
 
 // Symbol: __OSShutdownDevices
-// Function signature is unknown.
 // PAL: 0x801a8370..0x801a8500
 MARK_BINARY_BLOB(__OSShutdownDevices, 0x801a8370, 0x801a8500);
 asm UNKNOWN_FUNCTION(__OSShutdownDevices) {
@@ -302,7 +299,6 @@ lbl_801a84e0:
 }
 
 // Symbol: __OSGetDiscState
-// Function signature is unknown.
 // PAL: 0x801a8500..0x801a856c
 MARK_BINARY_BLOB(__OSGetDiscState, 0x801a8500, 0x801a856c);
 asm UNKNOWN_FUNCTION(__OSGetDiscState) {
@@ -342,7 +338,6 @@ lbl_801a8558:
 }
 
 // Symbol: OSShutdownSystem
-// Function signature is unknown.
 // PAL: 0x801a856c..0x801a8688
 MARK_BINARY_BLOB(OSShutdownSystem, 0x801a856c, 0x801a8688);
 asm UNKNOWN_FUNCTION(OSShutdownSystem) {
@@ -431,7 +426,6 @@ lbl_801a8674:
 }
 
 // Symbol: OSRestart
-// Function signature is unknown.
 // PAL: 0x801a8688..0x801a8758
 MARK_BINARY_BLOB(OSRestart, 0x801a8688, 0x801a8758);
 asm UNKNOWN_FUNCTION(OSRestart) {
@@ -497,7 +491,6 @@ lbl_801a8720:
 }
 
 // Symbol: __OSReturnToMenu
-// Function signature is unknown.
 // PAL: 0x801a8758..0x801a8858
 MARK_BINARY_BLOB(__OSReturnToMenu, 0x801a8758, 0x801a8858);
 asm UNKNOWN_FUNCTION(__OSReturnToMenu) {
@@ -576,7 +569,6 @@ lbl_801a8820:
 }
 
 // Symbol: OSReturnToMenu
-// Function signature is unknown.
 // PAL: 0x801a8858..0x801a8898
 MARK_BINARY_BLOB(OSReturnToMenu, 0x801a8858, 0x801a8898);
 asm UNKNOWN_FUNCTION(OSReturnToMenu) {
@@ -602,7 +594,6 @@ asm UNKNOWN_FUNCTION(OSReturnToMenu) {
 }
 
 // Symbol: OSReturnToSetting
-// Function signature is unknown.
 // PAL: 0x801a8898..0x801a8954
 MARK_BINARY_BLOB(OSReturnToSetting, 0x801a8898, 0x801a8954);
 asm UNKNOWN_FUNCTION(OSReturnToSetting) {
@@ -661,7 +652,6 @@ lbl_801a892c:
 }
 
 // Symbol: __OSReturnToMenuForError
-// Function signature is unknown.
 // PAL: 0x801a8954..0x801a89f8
 MARK_BINARY_BLOB(__OSReturnToMenuForError, 0x801a8954, 0x801a89f8);
 asm UNKNOWN_FUNCTION(__OSReturnToMenuForError) {
@@ -714,7 +704,6 @@ lbl_801a89b8:
 }
 
 // Symbol: __OSHotResetForError
-// Function signature is unknown.
 // PAL: 0x801a89f8..0x801a8a50
 MARK_BINARY_BLOB(__OSHotResetForError, 0x801a89f8, 0x801a8a50);
 asm UNKNOWN_FUNCTION(__OSHotResetForError) {
@@ -748,7 +737,6 @@ lbl_801a8a20:
 }
 
 // Symbol: OSGetResetCode
-// Function signature is unknown.
 // PAL: 0x801a8a50..0x801a8a80
 MARK_BINARY_BLOB(OSGetResetCode, 0x801a8a50, 0x801a8a80);
 asm UNKNOWN_FUNCTION(OSGetResetCode) {

--- a/source/rvl/os/osRtc.c
+++ b/source/rvl/os/osRtc.c
@@ -22,7 +22,6 @@ extern UNKNOWN_FUNCTION(EXILock);
 extern UNKNOWN_FUNCTION(EXIUnlock);
 
 // Symbol: WriteSramCallback
-// Function signature is unknown.
 // PAL: 0x801a8a9c..0x801a8bd4
 MARK_BINARY_BLOB(WriteSramCallback, 0x801a8a9c, 0x801a8bd4);
 asm UNKNOWN_FUNCTION(WriteSramCallback) {
@@ -114,7 +113,6 @@ lbl_801a8bb8:
 }
 
 // Symbol: __OSInitSram
-// Function signature is unknown.
 // PAL: 0x801a8bd4..0x801a8dd4
 MARK_BINARY_BLOB(__OSInitSram, 0x801a8bd4, 0x801a8dd4);
 asm UNKNOWN_FUNCTION(__OSInitSram) {
@@ -263,7 +261,6 @@ lbl_801a8dbc:
 }
 
 // Symbol: UnlockSram
-// Function signature is unknown.
 // PAL: 0x801a8dd4..0x801a90b4
 MARK_BINARY_BLOB(UnlockSram, 0x801a8dd4, 0x801a90b4);
 asm UNKNOWN_FUNCTION(UnlockSram) {
@@ -469,7 +466,6 @@ lbl_801a907c:
 }
 
 // Symbol: __OSSyncSram
-// Function signature is unknown.
 // PAL: 0x801a90b4..0x801a90c4
 MARK_BINARY_BLOB(__OSSyncSram, 0x801a90b4, 0x801a90c4);
 asm UNKNOWN_FUNCTION(__OSSyncSram) {
@@ -483,7 +479,6 @@ asm UNKNOWN_FUNCTION(__OSSyncSram) {
 }
 
 // Symbol: __OSReadROM
-// Function signature is unknown.
 // PAL: 0x801a90c4..0x801a91e8
 MARK_BINARY_BLOB(__OSReadROM, 0x801a90c4, 0x801a91e8);
 asm UNKNOWN_FUNCTION(__OSReadROM) {
@@ -569,7 +564,6 @@ lbl_801a91cc:
 }
 
 // Symbol: OSGetWirelessID
-// Function signature is unknown.
 // PAL: 0x801a91e8..0x801a9260
 MARK_BINARY_BLOB(OSGetWirelessID, 0x801a91e8, 0x801a9260);
 asm UNKNOWN_FUNCTION(OSGetWirelessID) {
@@ -611,7 +605,6 @@ lbl_801a9230:
 }
 
 // Symbol: OSSetWirelessID
-// Function signature is unknown.
 // PAL: 0x801a9260..0x801a92fc
 MARK_BINARY_BLOB(OSSetWirelessID, 0x801a9260, 0x801a92fc);
 asm UNKNOWN_FUNCTION(OSSetWirelessID) {
@@ -664,7 +657,6 @@ lbl_801a92e4:
 }
 
 // Symbol: __OSGetRTCFlags
-// Function signature is unknown.
 // PAL: 0x801a92fc..0x801a9418
 MARK_BINARY_BLOB(__OSGetRTCFlags, 0x801a92fc, 0x801a9418);
 asm UNKNOWN_FUNCTION(__OSGetRTCFlags) {
@@ -748,7 +740,6 @@ lbl_801a9400:
 }
 
 // Symbol: __OSClearRTCFlags
-// Function signature is unknown.
 // PAL: 0x801a9418..0x801a9528
 MARK_BINARY_BLOB(__OSClearRTCFlags, 0x801a9418, 0x801a9528);
 asm UNKNOWN_FUNCTION(__OSClearRTCFlags) {

--- a/source/rvl/os/osSync.c
+++ b/source/rvl/os/osSync.c
@@ -5,7 +5,6 @@
 #include "osCache.h"
 
 // Symbol: SystemCallVector
-// Function signature is unknown.
 // PAL: 0x801a9528..0x801a9548
 MARK_BINARY_BLOB(SystemCallVector, 0x801a9528, 0x801a9548);
 asm UNKNOWN_FUNCTION(SystemCallVector) {
@@ -23,7 +22,6 @@ asm UNKNOWN_FUNCTION(SystemCallVector) {
 }
 
 // Symbol: __OSInitSystemCall
-// Function signature is unknown.
 // PAL: 0x801a9548..0x801a95a8
 MARK_BINARY_BLOB(__OSInitSystemCall, 0x801a9548, 0x801a95a8);
 asm UNKNOWN_FUNCTION(__OSInitSystemCall) {

--- a/source/rvl/os/osThread.c
+++ b/source/rvl/os/osThread.c
@@ -58,7 +58,6 @@ lbl_801a9604:
 }
 
 // Symbol: __OSThreadInit
-// Function signature is unknown.
 // PAL: 0x801a961c..0x801a98a0
 MARK_BINARY_BLOB(__OSThreadInit, 0x801a961c, 0x801a98a0);
 asm UNKNOWN_FUNCTION(__OSThreadInit) {
@@ -237,7 +236,6 @@ lbl_801a9864:
 }
 
 // Symbol: OSInitThreadQueue
-// Function signature is unknown.
 // PAL: 0x801a98a0..0x801a98b0
 MARK_BINARY_BLOB(OSInitThreadQueue, 0x801a98a0, 0x801a98b0);
 asm void OSInitThreadQueue(struct OSThreadQueue*) {
@@ -284,7 +282,6 @@ lbl_801a98d8:
 }
 
 // Symbol: OSDisableScheduler
-// Function signature is unknown.
 // PAL: 0x801a98e8..0x801a9924
 MARK_BINARY_BLOB(OSDisableScheduler, 0x801a98e8, 0x801a9924);
 asm UNKNOWN_FUNCTION(OSDisableScheduler) {
@@ -309,7 +306,6 @@ asm UNKNOWN_FUNCTION(OSDisableScheduler) {
 }
 
 // Symbol: OSEnableScheduler
-// Function signature is unknown.
 // PAL: 0x801a9924..0x801a9960
 MARK_BINARY_BLOB(OSEnableScheduler, 0x801a9924, 0x801a9960);
 asm UNKNOWN_FUNCTION(OSEnableScheduler) {
@@ -334,7 +330,6 @@ asm UNKNOWN_FUNCTION(OSEnableScheduler) {
 }
 
 // Symbol: UnsetRun
-// Function signature is unknown.
 // PAL: 0x801a9960..0x801a99c8
 MARK_BINARY_BLOB(UnsetRun, 0x801a9960, 0x801a99c8);
 asm UNKNOWN_FUNCTION(UnsetRun) {
@@ -375,7 +370,6 @@ lbl_801a99bc:
 }
 
 // Symbol: __OSGetEffectivePriority
-// Function signature is unknown.
 // PAL: 0x801a99c8..0x801a9a04
 MARK_BINARY_BLOB(__OSGetEffectivePriority, 0x801a99c8, 0x801a9a04);
 asm UNKNOWN_FUNCTION(__OSGetEffectivePriority) {
@@ -403,7 +397,6 @@ lbl_801a99f4:
 }
 
 // Symbol: SetEffectivePriority
-// Function signature is unknown.
 // PAL: 0x801a9a04..0x801a9bb8
 MARK_BINARY_BLOB(SetEffectivePriority, 0x801a9a04, 0x801a9bb8);
 asm UNKNOWN_FUNCTION(SetEffectivePriority) {
@@ -542,7 +535,6 @@ lbl_801a9ba0:
 }
 
 // Symbol: __OSPromoteThread
-// Function signature is unknown.
 // PAL: 0x801a9bb8..0x801a9c08
 MARK_BINARY_BLOB(__OSPromoteThread, 0x801a9bb8, 0x801a9c08);
 asm UNKNOWN_FUNCTION(__OSPromoteThread) {
@@ -574,7 +566,6 @@ lbl_801a9bf4:
 }
 
 // Symbol: SelectThread
-// Function signature is unknown.
 // PAL: 0x801a9c08..0x801a9e30
 MARK_BINARY_BLOB(SelectThread, 0x801a9c08, 0x801a9e30);
 asm UNKNOWN_FUNCTION(SelectThread) {
@@ -736,7 +727,6 @@ lbl_801a9e18:
 }
 
 // Symbol: __OSReschedule
-// Function signature is unknown.
 // PAL: 0x801a9e30..0x801a9e48
 MARK_BINARY_BLOB(__OSReschedule, 0x801a9e30, 0x801a9e48);
 asm UNKNOWN_FUNCTION(__OSReschedule) {
@@ -752,7 +742,6 @@ asm UNKNOWN_FUNCTION(__OSReschedule) {
 }
 
 // Symbol: OSYieldThread
-// Function signature is unknown.
 // PAL: 0x801a9e48..0x801a9e84
 MARK_BINARY_BLOB(OSYieldThread, 0x801a9e48, 0x801a9e84);
 asm UNKNOWN_FUNCTION(OSYieldThread) {
@@ -950,7 +939,6 @@ lbl_801aa0d8:
 }
 
 // Symbol: OSExitThread
-// Function signature is unknown.
 // PAL: 0x801aa0f0..0x801aa1d4
 MARK_BINARY_BLOB(OSExitThread, 0x801aa0f0, 0x801aa1d4);
 asm UNKNOWN_FUNCTION(OSExitThread) {
@@ -1173,7 +1161,6 @@ lbl_801aa394:
 }
 
 // Symbol: OSJoinThread
-// Function signature is unknown.
 // PAL: 0x801aa3ac..0x801aa4ec
 MARK_BINARY_BLOB(OSJoinThread, 0x801aa3ac, 0x801aa4ec);
 asm UNKNOWN_FUNCTION(OSJoinThread) {
@@ -1534,7 +1521,6 @@ lbl_801aa7fc:
 }
 
 // Symbol: OSSuspendThread
-// Function signature is unknown.
 // PAL: 0x801aa824..0x801aa9b8
 MARK_BINARY_BLOB(OSSuspendThread, 0x801aa824, 0x801aa9b8);
 asm UNKNOWN_FUNCTION(OSSuspendThread) {
@@ -1815,7 +1801,6 @@ lbl_801aab78:
 }
 
 // Symbol: OSSetThreadPriority
-// Function signature is unknown.
 // PAL: 0x801aab98..0x801aaca8
 MARK_BINARY_BLOB(OSSetThreadPriority, 0x801aab98, 0x801aaca8);
 asm UNKNOWN_FUNCTION(OSSetThreadPriority) {


### PR DESCRIPTION
Not necessary to say "Remove useless comment" when the macro `UNKNOWN_FUNCTION` already implies that.