### PR TITLE
More diff.py improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ tools.zip
 .~lock.*
 
 doxygen
+
+# diff.py expected
+expected

--- a/build.py
+++ b/build.py
@@ -181,7 +181,7 @@ CW_ARGS = [
     "-nostdinc",
     "-msgstyle gcc -lang=c99 -DREVOKART",
     "-func_align 4",
-    "-sym dwarf-2",
+    "-sym on",
 ]
 
 # Hack: $@ doesn't behave properly with this

--- a/build.py
+++ b/build.py
@@ -181,7 +181,7 @@ CW_ARGS = [
     "-nostdinc",
     "-msgstyle gcc -lang=c99 -DREVOKART",
     "-func_align 4",
-    "-sym on",
+    "-sym dwarf-2",
 ]
 
 # Hack: $@ doesn't behave properly with this

--- a/diff.py
+++ b/diff.py
@@ -3,7 +3,7 @@
 
 """
 Imported from https://github.com/simonlindholm/asm-differ/
-on commit 291173ed30e8a6dc91c28334aa1275a555d725b1
+on commit e7d0aaf06ce7f73acc2870bbc0f6ef66c76cb46a
 
 Edits:
     Dol & rel ram-rom conversion added using mkwutil
@@ -1979,7 +1979,7 @@ def process(dump: str, config: Config) -> List[Line]:
             # This regex is conservative, and assumes the file path does not contain "weird"
             # characters like colons, tabs, or angle brackets.
             if re.match(
-                r"^[^ \t<>:][^\t<>:]*:[0-9]+( \(discriminator [0-9]+\))?$", row
+                r"^[^ \t<>][^\t<>]*:[0-9]+( \(discriminator [0-9]+\))?$", row
             ):
                 source_filename, _, tail = row.rpartition(":")
                 source_line_num = int(tail.partition(" ")[0])

--- a/diff.py
+++ b/diff.py
@@ -1977,7 +1977,7 @@ def process(dump: str, config: Config) -> List[Line]:
 
         if not re.match(r"^\s+[0-9a-f]+:\s+", row):
             # This regex is conservative, and assumes the file path does not contain "weird"
-            # characters like colons, tabs, or angle brackets.
+            # characters like tabs or angle brackets.
             if re.match(
                 r"^[^ \t<>][^\t<>]*:[0-9]+( \(discriminator [0-9]+\))?$", row
             ):

--- a/diff_settings.py
+++ b/diff_settings.py
@@ -1,6 +1,7 @@
 from argparse import ArgumentParser
 import os
 from pathlib import Path
+from sys import executable
 
 DEVKITPPC = Path(os.environ.get("DEVKITPPC", "./tools/devkitppc"))
 
@@ -14,6 +15,7 @@ def apply(config: dict, args):
         config["mapfile"] = "artifacts/target/pal/main.map"
         config["myimg"] = "artifacts/target/pal/main.dol"
         config["baseimg"] = "artifacts/orig/pal/main.dol"
+    config["make_command"] = [executable, "build.py", "--diff_py"]
     config["makeflags"] = []
     config["source_directories"] = ["source"]
     config["arch"] = "ppc"

--- a/diff_settings.py
+++ b/diff_settings.py
@@ -23,7 +23,6 @@ def apply(config: dict, args):
     config["mw_build_dir"] = "out"  # only needed for mw map format
     config["makeflags"] = []
     config["objdump_executable"] = DEVKITPPC / "bin" / "powerpc-eabi-objdump.exe"
-    config["show_line_numbers_default"] = True
 
 def add_custom_arguments(parser: ArgumentParser):
     parser.add_argument("-r", "--rel", action="store_true", help="(MKW) Diff a function in staticR.rel")

--- a/diff_settings.py
+++ b/diff_settings.py
@@ -23,6 +23,7 @@ def apply(config: dict, args):
     config["mw_build_dir"] = "out"  # only needed for mw map format
     config["makeflags"] = []
     config["objdump_executable"] = DEVKITPPC / "bin" / "powerpc-eabi-objdump.exe"
+    config["show_line_numbers_default"] = True
 
 def add_custom_arguments(parser: ArgumentParser):
     parser.add_argument("-r", "--rel", action="store_true", help="(MKW) Diff a function in staticR.rel")

--- a/expected.py
+++ b/expected.py
@@ -1,0 +1,14 @@
+"""
+Creates the expected folder for diff.py
+"""
+
+from shutil import copytree, rmtree
+
+# Remove it if already existing
+try:
+    rmtree("expected")
+except FileNotFoundError:
+    pass
+
+# Copy in out and artifacts directories
+copytree("out", "expected/out")


### PR DESCRIPTION
- Updated diff.py to the latest version from the original repo again (the update merged the arch_settings and mapfile regex changes this repo had into the main repo, and also added `--stop-at-ret` support for ppc to end the diff on the first blr found).
- Set up this repo for .o diffing, which allows relocations with symbol names to be included in the diff (to use, run expected.py on an OK build and then use diff.py with -o)
- Set up this repo for automatic rebuilding (run diff.py with the flags -mw and it will rebuild automatically whenever you edit the source code & update the diff, like on decomp.me)
- Set up this repo for showing line numbers in the diff