### PR TITLE
General improvements to infrastructure

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -42,6 +42,7 @@ def parse_args():
     parser.add_argument("--regen_asm", action="store_true", help="Regenerate all ASM")
     parser.add_argument("--force_analyse", action="store_true", help="Force run original binary analysis")
     parser.add_argument("--link_only", action="store_true", help="Link only, don't build")
+    parser.add_argument("--full_errors", action="store_true", help="Show full error log")
     args = parser.parse_args()
     return args
 
@@ -305,13 +306,15 @@ def add_compile_rules(args, n: Writer):
         srcPath = Path(src.src)
         o_path = str((Path("out") / srcPath.parts[-1]).with_suffix(".o"))
 
+        error_cap = 0 if args.full_errors else 1
+
         n.build(
             o_path,
             rule = "cc",
             inputs = src.src,
             variables = {
                 "cc" : get_compat_cmd(CWCC_PATHS[src.cc]),
-                "cflags" : CWCC_OPT + ' ' + src.opts,
+                "cflags" : CWCC_OPT + f' -maxerrors {error_cap} ' + src.opts,
             }
         )
 

--- a/source/rk_types.h
+++ b/source/rk_types.h
@@ -116,6 +116,8 @@ public:
 private:
   inline NonCopyable(const NonCopyable&) {}
 };
+
+#define static_assert(cond) __static_assert(cond, #cond)
 #endif // __cplusplus
 
 #define INLINE_ELSEWHERE(x)


### PR DESCRIPTION
Credit to @SeekyCt and @CLF78 for the guidance. Static asserts are primarily useful in ensuring that the size of a class stays the same, and that the offset of a member is correct. Static assertion fails will yield an error, but they can be drowned in a sea of "undefined identifier" and "data object redefined". To counteract this, the default build will only show one error, unless we give the `--full_errors` flag to configure.py.