### PR TITLE
Match Net::ROOMHandler::reset()

### DIFF
--- a/src/net/packets/ROOM.cpp
+++ b/src/net/packets/ROOM.cpp
@@ -1,3 +1,41 @@
 #include "ROOM.hpp"
 
-namespace Net {}
+namespace Net {
+
+void ROOMHandler::reset() {
+  u8* self = (u8*)this;
+  u8** new_var;
+  *self = 0;
+  *(u32*)(self + 0x08) = 0;
+  *(u32*)(self + 0x38) = 0;
+  *(u32*)(self + 0x0c) = 0;
+  *(u32*)(self + 0x3c) = 0;
+  *(u32*)(self + 0x10) = 0;
+  *(u32*)(self + 0x40) = 0;
+  *(u32*)(self + 0x14) = 0;
+  *(u32*)(self + 0x44) = 0;
+  *(u32*)(self + 0x18) = 0;
+  *(u32*)(self + 0x48) = 0;
+  *(u32*)(self + 0x1c) = 0;
+  *(u32*)(self + 0x4c) = 0;
+  *(u32*)(self + 0x20) = 0;
+  *(u32*)(self + 0x50) = 0;
+  *(u32*)(self + 0x24) = 0;
+  *(u32*)(self + 0x54) = 0;
+  *(u32*)(self + 0x28) = 0;
+  *(u32*)(self + 0x58) = 0;
+  *(u32*)(self + 0x2c) = 0;
+  *(u32*)(self + 0x5c) = 0;
+  *(u32*)(self + 0x30) = 0;
+  *(u32*)(self + 0x60) = 0;
+  *(u32*)(self + 0x34) = 0;
+  *(u32*)(self + 0x64) = 0;
+  self[0x68] = 0xff;
+  *(u32*)((*(new_var = &self)) + 0x74) = 0;
+  *(u32*)((*new_var) + 0x70) = 0;
+  *(u32*)((*new_var) + 0x7c) = 0;
+  if (!(*new_var)) {}
+  *(u32*)((*new_var) + 0x78) = 0;
+}
+
+} // namespace Net


### PR DESCRIPTION
## Summary

Adds a 100% byte-matching implementation for `Net::ROOMHandler::reset()` (declared in `src/net/packets/ROOM.hpp` but not yet defined).

The function zeros out 28 `u32` fields in the handler, sets a `0xff` byte at offset `0x68`, then zeros 4 final `u32` fields at `0x74`, `0x70`, `0x7c`, `0x78`.

## How

Found via [decomp-permuter](https://github.com/simonlindholm/decomp-permuter). The trailing 4 stores require an indirect-via-double-pointer trick (`u8** new_var = &self`) plus a dummy null check to force mwcc into the matching instruction sequence — without it, mwcc picks a different scheduling that fails to byte-match.

The class definition only exposes a `_00[0x80]` opaque buffer, so the implementation uses `u8* self = (u8*)this;` to write at raw offsets. This stays consistent with the current header style.

## Test plan

- [x] objdiff: `reset__Q23Net11ROOMHandlerFv` reports 100% match
- [x] Full build still produces matching `main.dol` (`ac7d72448630ade7655fc8bc5fd7a6543cb53a49`) and `StaticR.rel` (`887bcc076781f5b005cc317a6e3cc8fd5f911300`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)