### PR TITLE
Match 6 more NandUtil_* functions

### DIFF
--- a/src/system/NandUtil.cpp
+++ b/src/system/NandUtil.cpp
@@ -149,7 +149,227 @@ int NandUtil_close(NANDFileInfo* a1) {
   return v4;
 }
 
+
+int NandUtil_getLength(NANDFileInfo* a1, u32* a2) {
+  int v7; // r27
+  int v8; // r26
+
+  v7 = 1;
+  v8 = 8;
+  for (int v1 = 0; v1 < 3; ++v1) {
+    switch (NANDGetLength(a1, a2)) {
+    case 0:
+      v8 = 0;
+      break;
+    case -3:
+    case -2:
+      if (v1 >= 3)
+        v8 = 2; // not reached
+      else
+        v7 = 0;
+      break;
+    case -4:
+      v8 = 6;
+      break;
+    default:
+      v8 = 8;
+      break;
+    }
+    if (v7)
+      break;
+    OSSleepTicks(OSMillisecondsToTicks(100ll));
+  }
+  return v8;
+}
+
+
+
+int NandUtil_createDir(const char* a1, u8 a2) {
+  int v6; // r27
+  int v7; // r26
+
+  v6 = 1;
+  v7 = 8;
+  for (int v1 = 0; v1 < 3; ++v1) {
+    switch (NANDCreateDir(a1, a2, 0)) {
+    case 0:
+    case -6:
+      v7 = 0;
+      break;
+    case -3:
+    case -2:
+      if (v1 >= 3)
+        v7 = 2; // not reached
+      else
+        v6 = 0;
+      break;
+    case -4:
+      v7 = 6;
+      break;
+    case -1:
+      v7 = 3;
+      break;
+    default:
+      v7 = 8;
+      break;
+    }
+    if (v6)
+      break;
+    OSSleepTicks(OSMillisecondsToTicks(100ll));
+  }
+  return v7;
+}
+
+
+int NandUtil_create(const char* a1, u8 a2) {
+  int v6; // r27
+  int v7; // r26
+
+  v6 = 1;
+  v7 = 8;
+  for (int v1 = 0; v1 < 3; ++v1) {
+    switch (NANDCreate(a1, a2, 0)) {
+    case 0:
+    case -6:
+      v7 = 0;
+      break;
+    case -3:
+    case -2:
+      if (v1 >= 3)
+        v7 = 2; // not reached
+      else
+        v6 = 0;
+      break;
+    case -4:
+      v7 = 6;
+      break;
+    case -1:
+      v7 = 3;
+      break;
+    default:
+      v7 = 8;
+      break;
+    }
+    if (v6)
+      break;
+    OSSleepTicks(OSMillisecondsToTicks(100ll));
+  }
+  return v7;
+}
+
+int NandUtil_delete(const char* a1) {
+  int v5; // r27
+  int v6; // r26
+
+  v5 = 1;
+  v6 = 8;
+  for (int v1 = 0; v1 < 3; ++v1) {
+    switch (NANDDelete(a1)) {
+    case 0:
+    case -12:
+      v6 = 0;
+      break;
+    case -3:
+    case -2:
+      if (v1 >= 3)
+        v6 = 2; // not reached
+      else
+        v5 = 0;
+      break;
+    case -4:
+      v6 = 6;
+      break;
+    case -1:
+      v6 = 3;
+      break;
+    default:
+      v6 = 8;
+      break;
+    }
+    if (v5)
+      break;
+    OSSleepTicks(OSMillisecondsToTicks(100ll));
+  }
+  return v6;
+}
+
+int NandUtil_setStatus(const char* a1, const NANDStatus* a2) {
+  int v6; // r27
+  int v7; // r26
+
+  v6 = 1;
+  v7 = 8;
+  for (int v1 = 0; v1 < 3; ++v1) {
+    switch (NANDSetStatus(a1, a2)) {
+    case 0:
+      v7 = 0;
+      break;
+    case -3:
+    case -2:
+      if (v1 >= 3)
+        v7 = 2; // not reached
+      else
+        v6 = 0;
+      break;
+    case -12:
+      v7 = 4;
+      break;
+    case -4:
+      v7 = 6;
+      break;
+    case -1:
+      v7 = 3;
+      break;
+    default:
+      v7 = 8;
+      break;
+    }
+    if (v6)
+      break;
+    OSSleepTicks(OSMillisecondsToTicks(100ll));
+  }
+  return v7;
+}
+
+int NandUtil_getStatus(const char* a1, NANDStatus* a2) {
+  int v6; // r27
+  int v7; // r26
+
+  v6 = 1;
+  v7 = 8;
+  for (int v1 = 0; v1 < 3; ++v1) {
+    switch (NANDGetStatus(a1, a2)) {
+    case 0:
+      v7 = 0;
+      break;
+    case -3:
+    case -2:
+      if (v1 >= 3)
+        v7 = 2; // not reached
+      else
+        v6 = 0;
+      break;
+    case -12:
+      v7 = 4;
+      break;
+    case -4:
+      v7 = 6;
+      break;
+    case -1:
+      v7 = 3;
+      break;
+    default:
+      v7 = 8;
+      break;
+    }
+    if (v6)
+      break;
+    OSSleepTicks(OSMillisecondsToTicks(100ll));
+  }
+  return v7;
+}
+
 void unk_8052bd38(void* first) {
-  u16 tmp[4];
-  NandUtil_getStatus(first, &tmp[0]);
+  NANDStatus tmp;
+  NandUtil_getStatus((const char*)first, &tmp);
 }

--- a/src/system/NandUtil.hpp
+++ b/src/system/NandUtil.hpp
@@ -15,7 +15,12 @@ int NandUtil_safeOpen(const char* a1, NANDFileInfo* a2, u8 a3, void* a4,
 int NandUtil_open(const char* a1, NANDFileInfo* a2, u8 a3);
 int NandUtil_safeClose(NANDFileInfo* a1);
 int NandUtil_close(NANDFileInfo* a1);
-int NandUtil_getStatus(void*, void*);
+int NandUtil_getLength(NANDFileInfo* a1, u32* a2);
+int NandUtil_createDir(const char* a1, u8 a2);
+int NandUtil_create(const char* a1, u8 a2);
+int NandUtil_delete(const char* a1);
+int NandUtil_setStatus(const char* a1, const NANDStatus* a2);
+int NandUtil_getStatus(const char* a1, NANDStatus* a2);
 void unk_8052bd38(void* first);
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Summary

Adds matching (100% byte-match) implementations for 6 previously-undefined `NandUtil_*` functions:

- `NandUtil_getLength`
- `NandUtil_createDir`
- `NandUtil_create`
- `NandUtil_delete`
- `NandUtil_setStatus`
- `NandUtil_getStatus`

Also fixes the `NandUtil_getStatus` header signature (was `(void*, void*)`, actually `(const char*, NANDStatus*)`).

## Test plan

- [x] objdiff: 11/11 functions in `NandUtil.o` report 100% match
- [x] Full build still produces matching ROM:
  - `main.dol` sha1 `ac7d72448630ade7655fc8bc5fd7a6543cb53a49`
  - `StaticR.rel` sha1 `887bcc076781f5b005cc317a6e3cc8fd5f911300`

🤖 Generated with [Claude Code](https://claude.com/claude-code)