### PR TITLE
Match Net::USERHandler::update()

### DIFF
--- a/src/net/packets/USER.cpp
+++ b/src/net/packets/USER.cpp
@@ -1,3 +1,47 @@
 #include "USER.hpp"
 
-namespace Net {}
+#include "net/NetManager.hpp"
+
+#include <string.h>
+
+extern "C" {
+void fn_1_152498(void*);
+void fn_1_152B08(void*);
+s32 RFLGetAsyncStatus();
+}
+
+namespace Net {
+
+void USERHandler::update() {
+  if (NetManager::getInstance()->hasFoundMatch()) {
+    if (*(u8*)this == 0) {
+      fn_1_152498(this);
+    }
+  } else {
+    if (*(u8*)this != 0) {
+      *(u8*)this = 0;
+      *(u32*)((char*)this + 0x9e0) = 0;
+      *(u32*)((char*)this + 0x9e4) = 0;
+      *(u32*)((char*)this + 0x9e8) = 0;
+      memset((char*)this + 0x8, 0, 0xc0);
+      u32 i;
+      char* p = (char*)this + 0xc8;
+      for (i = 0; i < 0xc; i++) {
+        memset(p, 0, 0xc0);
+        p += 0xc0;
+      }
+    }
+  }
+  if (*(u8*)this != 0) {
+    fn_1_152B08(this);
+    if (*(s32*)((char*)this + 0x9dc) == 1) {
+      if (RFLGetAsyncStatus() != 6) {
+        *(u32*)((char*)this + 0x9e0) = *(u32*)((char*)this + 0x9e8);
+        *(u32*)((char*)this + 0x9e8) = 0;
+        *(u32*)((char*)this + 0x9dc) = 0;
+      }
+    }
+  }
+}
+
+} // namespace Net


### PR DESCRIPTION
## Summary

Adds a 100% byte-matching implementation for `Net::USERHandler::update()` (declared in `src/net/packets/USER.hpp` but not yet defined).

The method checks `NetManager::getInstance()->hasFoundMatch()`:
- match found + state==0 → call internal init helper
- no match + state!=0 → reset internal state (clear status fields + memset payload arrays)
- always: if state!=0, run periodic update + check RFL async status

## Internal helpers

Calls `fn_1_152498` and `fn_1_152B08` (forward-declared `extern "C"`). These don't yet have proper names — they continue to be provided via the asm fallback. Once those get matched + named in a follow-up, the `extern "C"` declarations can be replaced.

## Test plan

- [x] `objdiff-cli -x update__Q23Net11USERHandlerFv`: 100% match (relaxed reloc — only the call targets to unmatched helpers differ in symbol naming, machine code is byte-identical)
- [x] Full build still produces matching ROM:
  - `main.dol` sha1 `ac7d72448630ade7655fc8bc5fd7a6543cb53a49`
  - `StaticR.rel` sha1 `887bcc076781f5b005cc317a6e3cc8fd5f911300`

🤖 Generated with [Claude Code](https://claude.com/claude-code)